### PR TITLE
Fix ingot pile and plank crashes.

### DIFF
--- a/TFC_Shared/src/TFC/Items/ItemIngot.java
+++ b/TFC_Shared/src/TFC/Items/ItemIngot.java
@@ -353,7 +353,8 @@ public class ItemIngot extends ItemTerra
 				{
 					setSide(world, itemstack, m, dir, x, y, z, 1, 0, 0);
 				}
-				if (world.getBlockTileEntity(x,y,z) != null){
+				if (world.getBlockTileEntity(x,y,z) != null && world.getBlockTileEntity(x,y,z) instanceof TileEntityIngotPile)
+            {
 					((TileEntityIngotPile)world.getBlockTileEntity(x,y,z)).setType(this.itemID - 16028 - 256);
 				}
 				world.addBlockEvent(x,y,z,TFCBlocks.IngotPile.blockID,0,0);

--- a/TFC_Shared/src/TFC/Items/ItemPlank.java
+++ b/TFC_Shared/src/TFC/Items/ItemPlank.java
@@ -64,14 +64,14 @@ public class ItemPlank extends ItemTerra
 					world.setBlock(i, j-1, k, TFCBlocks.WoodConstruct.blockID);
 
 				TileEntity tile = world.getBlockTileEntity(i, j-offset, k);
-				if(tile!= null)
-				{
-					TileEntityWoodConstruct te = (TileEntityWoodConstruct)tile;
-					te.data.set(dd+(x+(z*d)));
-					te.woodTypes[dd+(x+(z*d))] = (byte) is.getItemDamage();
+				if((tile == null) || (!(tile instanceof TileEntityWoodConstruct)))
+					return false;
 
-					te.broadcastPacketInRange(te.createUpdatePacket(dd+(x+(z*d)), (byte) is.getItemDamage()));
-				}
+				TileEntityWoodConstruct te = (TileEntityWoodConstruct)tile;
+				te.data.set(dd+(x+(z*d)));
+				te.woodTypes[dd+(x+(z*d))] = (byte) is.getItemDamage();
+
+				te.broadcastPacketInRange(te.createUpdatePacket(dd+(x+(z*d)), (byte) is.getItemDamage()));
 			}
 			else if(side == 1)
 			{
@@ -79,14 +79,14 @@ public class ItemPlank extends ItemTerra
 					world.setBlock(i, j+1, k, TFCBlocks.WoodConstruct.blockID);
 
 				TileEntity tile = world.getBlockTileEntity(i, j+offset, k);
-				if(tile!= null)
-				{
-					TileEntityWoodConstruct te = (TileEntityWoodConstruct)tile;
-					te.data.set(dd+(x+(z*d)));
-					te.woodTypes[dd+(x+(z*d))] = (byte) is.getItemDamage();
+				if((tile == null) || (!(tile instanceof TileEntityWoodConstruct)))
+					return false;
 
-					te.broadcastPacketInRange(te.createUpdatePacket(dd+(x+(z*d)), (byte) is.getItemDamage()));
-				}
+				TileEntityWoodConstruct te = (TileEntityWoodConstruct)tile;
+				te.data.set(dd+(x+(z*d)));
+				te.woodTypes[dd+(x+(z*d))] = (byte) is.getItemDamage();
+
+				te.broadcastPacketInRange(te.createUpdatePacket(dd+(x+(z*d)), (byte) is.getItemDamage()));
 			}
 			else if(side == 2)
 			{
@@ -94,14 +94,14 @@ public class ItemPlank extends ItemTerra
 					world.setBlock(i, j, k-1, TFCBlocks.WoodConstruct.blockID);
 
 				TileEntity tile = world.getBlockTileEntity(i, j, k-offset);
-				if(tile!= null)
-				{
-					TileEntityWoodConstruct te = (TileEntityWoodConstruct)tile;
-					te.data.set(dd2+(x+(y*d)));
-					te.woodTypes[dd2+(x+(y*d))] = (byte) is.getItemDamage();
+				if((tile == null) || (!(tile instanceof TileEntityWoodConstruct)))
+					return false;
 
-					te.broadcastPacketInRange(te.createUpdatePacket(dd2+(x+(y*d)), (byte) is.getItemDamage()));
-				}
+				TileEntityWoodConstruct te = (TileEntityWoodConstruct)tile;
+				te.data.set(dd2+(x+(y*d)));
+				te.woodTypes[dd2+(x+(y*d))] = (byte) is.getItemDamage();
+
+				te.broadcastPacketInRange(te.createUpdatePacket(dd2+(x+(y*d)), (byte) is.getItemDamage()));
 			}
 			else if(side == 3)
 			{
@@ -109,14 +109,14 @@ public class ItemPlank extends ItemTerra
 					world.setBlock(i, j, k+1, TFCBlocks.WoodConstruct.blockID);
 
 				TileEntity tile = world.getBlockTileEntity(i, j, k+offset);
-				if(tile!= null)
-				{
-					TileEntityWoodConstruct te = (TileEntityWoodConstruct)tile;
-					te.data.set(dd2+(x+(y*d)));
-					te.woodTypes[dd2+(x+(y*d))] = (byte) is.getItemDamage();
+				if((tile == null) || (!(tile instanceof TileEntityWoodConstruct)))
+					return false;
 
-					te.broadcastPacketInRange(te.createUpdatePacket(dd2+(x+(y*d)), (byte) is.getItemDamage()));
-				}
+				TileEntityWoodConstruct te = (TileEntityWoodConstruct)tile;
+				te.data.set(dd2+(x+(y*d)));
+				te.woodTypes[dd2+(x+(y*d))] = (byte) is.getItemDamage();
+
+				te.broadcastPacketInRange(te.createUpdatePacket(dd2+(x+(y*d)), (byte) is.getItemDamage()));
 			}
 			else if(side == 4)
 			{
@@ -124,14 +124,14 @@ public class ItemPlank extends ItemTerra
 					world.setBlock(i-1, j, k, TFCBlocks.WoodConstruct.blockID);
 
 				TileEntity tile = world.getBlockTileEntity(i-offset, j, k);
-				if(tile!= null)
-				{
-					TileEntityWoodConstruct te = (TileEntityWoodConstruct)tile;
-					te.data.set((y+(z*d)));
-					te.woodTypes[(y+(z*d))] = (byte) is.getItemDamage();
+				if((tile == null) || (!(tile instanceof TileEntityWoodConstruct)))
+					return false;
 
-					te.broadcastPacketInRange(te.createUpdatePacket((y+(z*d)), (byte) is.getItemDamage()));
-				}
+				TileEntityWoodConstruct te = (TileEntityWoodConstruct)tile;
+				te.data.set((y+(z*d)));
+				te.woodTypes[(y+(z*d))] = (byte) is.getItemDamage();
+
+				te.broadcastPacketInRange(te.createUpdatePacket((y+(z*d)), (byte) is.getItemDamage()));
 			}
 			else if(side == 5)
 			{
@@ -139,14 +139,14 @@ public class ItemPlank extends ItemTerra
 					world.setBlock(i+1, j, k, TFCBlocks.WoodConstruct.blockID);
 
 				TileEntity tile = world.getBlockTileEntity(i+offset, j, k);
-				if(tile!= null)
-				{
-					TileEntityWoodConstruct te = (TileEntityWoodConstruct)tile;
-					te.data.set((y+(z*d)));
-					te.woodTypes[(y+(z*d))] = (byte) is.getItemDamage();
+				if((tile == null) || (!(tile instanceof TileEntityWoodConstruct)))
+					return false;
 
-					te.broadcastPacketInRange(te.createUpdatePacket((y+(z*d)), (byte) is.getItemDamage()));
-				}
+				TileEntityWoodConstruct te = (TileEntityWoodConstruct)tile;
+				te.data.set((y+(z*d)));
+				te.woodTypes[(y+(z*d))] = (byte) is.getItemDamage();
+
+				te.broadcastPacketInRange(te.createUpdatePacket((y+(z*d)), (byte) is.getItemDamage()));
 			}
 			is.stackSize--;
 			return true;


### PR DESCRIPTION
Fix crash when placing ingot pile on top of log pile or chiseled block.
Fix crash when placing plank on block with sign or sapling.
Also, it no longer seems to lose planks when trying to place on top of grass or flowers.
