### PR TITLE
Fix instant cooking exploit with forge.

### DIFF
--- a/TFC_Shared/src/TFC/TileEntities/TileEntityForge.java
+++ b/TFC_Shared/src/TFC/TileEntities/TileEntityForge.java
@@ -201,6 +201,7 @@ public class TileEntityForge extends TileEntityFireEntity implements IInventory
                 inputCompound = new NBTTagCompound();
                 inputCompound.setFloat("temperature", startTemp);
                 fireItemStacks[i].setTagCompound(inputCompound);
+                inputItemTemps[i] = startTemp;
             }
         }
         else if(fireItemStacks[i] == null)


### PR DESCRIPTION
This fixes the problem where swapping an item with a finished one instantly cooks the new item.
