### PR TITLE
Fixed Firepit

### DIFF
--- a/TFC_Shared/src/TFC/Containers/SlotFirepit.java
+++ b/TFC_Shared/src/TFC/Containers/SlotFirepit.java
@@ -18,4 +18,9 @@ public class SlotFirepit extends Slot
 	{
 		return false;
 	}
+	
+	@Override
+	public int getSlotStackLimit() {
+		return 1;
+	}
 }

--- a/TFC_Shared/src/TFC/Containers/SlotFirepitFuel.java
+++ b/TFC_Shared/src/TFC/Containers/SlotFirepitFuel.java
@@ -25,24 +25,15 @@ public class SlotFirepitFuel extends Slot
 		return false;
 	}
 
-//	public void onPickupFromSlot(ItemStack itemstack)
-//	{
-//		super.onPickupFromSlot(itemstack);
-//	}
-//	
 	@Override
 	public int getSlotStackLimit()
     {
         return 1;
     }
-//    
-//    public void putStack(ItemStack par1ItemStack)
-//    {
-//        if(par1ItemStack != null){
-//        ItemStack is = par1ItemStack;
-//        par1ItemStack.stackSize -= 1;
-//        is.stackSize = 1;
-//        super.putStack(is);
-//        }
-//    }
+
+	@Override
+	public void putStack(ItemStack par1ItemStack) {
+		if (par1ItemStack != null) par1ItemStack.stackSize = 1;
+		super.putStack(par1ItemStack);
+	}
 }

--- a/TFC_Shared/src/TFC/Containers/SlotFirepitIn.java
+++ b/TFC_Shared/src/TFC/Containers/SlotFirepitIn.java
@@ -4,6 +4,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
+import TFC.TFCBlocks;
 import TFC.TFCItems;
 
 public class SlotFirepitIn extends Slot
@@ -23,9 +24,14 @@ public class SlotFirepitIn extends Slot
 	@Override
 	public boolean isItemValid(ItemStack is)
     {
-		if(is.itemID == TFCItems.Logs.itemID)
+		if(is.itemID == TFCItems.Logs.itemID || is.itemID == TFCBlocks.Peat.blockID)
 			return false;
         return true;
     }
-
+	
+	@Override
+	public void putStack(ItemStack par1ItemStack) {
+		if (par1ItemStack != null) par1ItemStack.stackSize = 1;
+		super.putStack(par1ItemStack);
+	}
 }

--- a/TFC_Shared/src/TFC/Containers/SlotFirepitOut.java
+++ b/TFC_Shared/src/TFC/Containers/SlotFirepitOut.java
@@ -51,9 +51,4 @@ public class SlotFirepitOut extends Slot
 
 		return false;
 	}
-	
-    public int getSlotStackLimit()
-    {
-        return 1;
-    }
 }

--- a/TFC_Shared/src/TFC/TileEntities/TileEntityFirepit.java
+++ b/TFC_Shared/src/TFC/TileEntities/TileEntityFirepit.java
@@ -339,6 +339,13 @@ public class TileEntityFirepit extends TileEntityFireEntity implements IInventor
                     {
                         fireItemStacks[8] = output.copy(); 
                     }
+                    else if((fireItemStacks[7].stackSize == fireItemStacks[7].getMaxStackSize() && fireItemStacks[8].stackSize == fireItemStacks[8].getMaxStackSize())
+                    		|| (fireItemStacks[7].getItem().itemID != output.getItem().itemID && fireItemStacks[8].getItem().itemID != output.getItem().itemID)
+                    		|| (fireItemStacks[7].stackSize == fireItemStacks[7].getMaxStackSize() && fireItemStacks[8].getItem().itemID != output.getItem().itemID)
+                    		|| (fireItemStacks[7].getItem().itemID != output.getItem().itemID && fireItemStacks[8].stackSize == fireItemStacks[8].getMaxStackSize()))
+                    {
+                    	fireItemStacks[1] = output.copy();
+                    }
                 }
             }
         }
@@ -561,8 +568,7 @@ public class TileEntityFirepit extends TileEntityFireEntity implements IInventor
     @Override
     public int getInventoryStackLimit()
     {
-        // TODO Auto-generated method stub
-        return 1;
+        return 64;
     }
 
     @Override


### PR DESCRIPTION
- Stack size will display correctly
- Shift-click will work as it should
- You will not lose your cooked item if both output slots are not free
- Peat will only go into the fuel slot with shift-click now
