### PR TITLE
Fixed Forge item duplicate exploit

### DIFF
--- a/TFC_Shared/src/TFC/Containers/ContainerTerraForge.java
+++ b/TFC_Shared/src/TFC/Containers/ContainerTerraForge.java
@@ -79,11 +79,10 @@ public class ContainerTerraForge extends ContainerTFC
 			ItemStack itemstack1 = slot.getStack();
 			if(i <= 13)
 			{
-				if(!entityplayer.inventory.addItemStackToInventory(itemstack1.copy()))
+				if(!this.mergeItemStack(itemstack1, 14, this.inventorySlots.size(), true))
 				{
 					return null;
 				}
-				slot.putStack(null);
 			}
 			else
 			{


### PR DESCRIPTION
When inventory is full, shift-click will duplicate the stack as long as
there is 1 of the same items in the inventory.
