### PR TITLE
Fixed some more shift-click bugs/exploits

### DIFF
--- a/TFC_Shared/src/TFC/Containers/ContainerTerraBarrel.java
+++ b/TFC_Shared/src/TFC/Containers/ContainerTerraBarrel.java
@@ -186,11 +186,10 @@ public class ContainerTerraBarrel extends ContainerTFC
 			ItemStack itemstack1 = slot.getStack();
 			if(i == 0)
 			{
-				if(!entityplayer.inventory.addItemStackToInventory(itemstack1.copy()))
+				if(!this.mergeItemStack(itemstack1, 1, this.inventorySlots.size(), true))
 				{
 					return null;
 				}
-				slot.putStack(null);
 			}
 			else
 			{
@@ -199,8 +198,8 @@ public class ContainerTerraBarrel extends ContainerTFC
 					return null;
 				}
 				ItemStack stack = itemstack1.copy();
-				stack.stackSize = 1;                            
-				slot1.putStack(stack);                          
+				stack.stackSize = 1;
+				slot1.putStack(stack);
 				itemstack1.stackSize--;
 			}
 			if(itemstack1.stackSize == 0)

--- a/TFC_Shared/src/TFC/Containers/ContainerTerraScribe.java
+++ b/TFC_Shared/src/TFC/Containers/ContainerTerraScribe.java
@@ -132,23 +132,24 @@ public class ContainerTerraScribe extends ContainerTFC
 			ItemStack itemstack1 = slot.getStack();
 			if(i == 0)
 			{
-				if(!entityplayer.inventory.addItemStackToInventory(itemstack1.copy()))
+				if(this.mergeItemStack(itemstack1, 27, this.inventorySlots.size(), true))
+				{
+					for (int j = 1; j <= 25; j++)
+					{
+						((Slot)inventorySlots.get(j)).decrStackSize(1);
+					}
+				}
+				else
 				{
 					return null;
-				}
-				slot.putStack(null);
-				for (int j = 1; j <= 25; j++)
-				{
-					((Slot)inventorySlots.get(j)).putStack(null);
 				}
 			}
 			else if(i <= 26)
 			{
-				if(!entityplayer.inventory.addItemStackToInventory(itemstack1.copy()))
+				if(!this.mergeItemStack(itemstack1, 27, this.inventorySlots.size(), true))
 				{
 					return null;
 				}
-				slot.putStack(null);
 			}
 			else if(itemstack1.itemID == Item.paper.itemID)
 			{

--- a/TFC_Shared/src/TFC/Containers/ContainerTerraSluice.java
+++ b/TFC_Shared/src/TFC/Containers/ContainerTerraSluice.java
@@ -85,11 +85,10 @@ public class ContainerTerraSluice extends ContainerTFC
 			ItemStack itemstack1 = slot.getStack();
 			if(i <= 8)
 			{
-				if(!player.inventory.addItemStackToInventory(itemstack1.copy()))
+				if(!this.mergeItemStack(itemstack1, 9, this.inventorySlots.size(), true))
 				{
 					return null;
 				}
-				slot.putStack(null);
 			}
 			if(itemstack1.stackSize == 0)
 			{


### PR DESCRIPTION
Fixed - Scribe table consumes all the ink on shift-click + on full inventory the plan will get deleted
Fixed - Barrel item duplication exploit
Fixed - Sluice item duplication exploit + shift-click with full inventory will delete the item
