### PR TITLE
Fix errant music filename which crashed the sound on Linux.

### DIFF
--- a/TFC_Shared/src/TFC/Core/TFC_Sounds.java
+++ b/TFC_Shared/src/TFC/Core/TFC_Sounds.java
@@ -26,7 +26,7 @@ public class TFC_Sounds
 		LOCATION_MUSIC + "FirmaVista.ogg",
 		LOCATION_MUSIC + "Sycamore Heights.ogg",
 		LOCATION_MUSIC + "Dreams of the Phae.ogg",
-		LOCATION_MUSIC + "TerraFirmaCraft.ogg"
+		LOCATION_MUSIC + "Terrafirmacraft.ogg"
 	};
 	
 	public static final String FALLININGROCKSHORT = PREFIX + "fallingrockshort";


### PR DESCRIPTION
When Minecraft tries to play a music file and doesn't find it, it throws the following exception:

```
Exception in thread "Thread-3" java.lang.NullPointerException
   at paulscode.sound.codecs.CodecJOrbis.initialize(CodecJOrbis.java:259)
   at paulscode.sound.libraries.SourceLWJGLOpenAL.play(SourceLWJGLOpenAL.java:616)
(...)
```

... and the sound thread is dead until the next restart. On Window this doesn't happen because the filesystem in case-insensitive, unlike on Linux.
