### PR TITLE
Shift-click merge fix

### DIFF
--- a/TFC_Shared/src/TFC/Containers/ContainerTFC.java
+++ b/TFC_Shared/src/TFC/Containers/ContainerTFC.java
@@ -35,8 +35,12 @@ public class ContainerTFC extends Container
                 slot = (Slot)this.inventorySlots.get(slotIndex);
                 slotstack = slot.getStack();
 
-                if (slotstack != null && slotstack.itemID == is.itemID && (!is.getHasSubtypes() || is.getItemDamage() == slotstack.getItemDamage()) && ItemStack.areItemStackTagsEqual(is, slotstack) && 
-                		slotstack.stackSize < slot.getSlotStackLimit())
+                if (slotstack != null
+                	&& slotstack.itemID == is.itemID
+                	&& !is.getHasSubtypes()
+                	&& is.getItemDamage() == slotstack.getItemDamage()
+                	&& ItemStack.areItemStackTagsEqual(is, slotstack)
+                	&& slotstack.stackSize < slot.getSlotStackLimit())
                 {
                     int mergedStackSize = is.stackSize + getSmaller(slotstack.stackSize, slot.getSlotStackLimit());
 


### PR DESCRIPTION
Shift-clicking will merge same item ids with different damage values,
taking the damage value from the inventory item.
