### PR TITLE
Fixed quern crash multiplayer

### DIFF
--- a/TFC_Shared/src/TFC/Blocks/Devices/BlockQuern.java
+++ b/TFC_Shared/src/TFC/Blocks/Devices/BlockQuern.java
@@ -32,6 +32,7 @@ public class BlockQuern extends BlockTerraContainer {
 		if(!world.isRemote) {
 			if(!te.shouldRotate && hitX >= 0.65 && hitZ >= 0.65 && te.storage[2] != null) {
 				te.shouldRotate = true;
+				TerraFirmaCraft.proxy.sendCustomPacketToPlayersInRange(x, y, z, te.createUpdatePacket(), 160);
 				world.playSoundEffect(x, y, z, TFC_Sounds.STONEDRAG, 1, 1);
 			}	
 			else if((!te.shouldRotate && (hitX < 0.65 || hitZ < 0.65)) || te.storage[2] == null) {

--- a/TFC_Shared/src/TFC/TileEntities/TileEntityQuern.java
+++ b/TFC_Shared/src/TFC/TileEntities/TileEntityQuern.java
@@ -162,8 +162,10 @@ public class TileEntityQuern extends NetworkTileEntity implements IInventory {
 		if(storage[i] != null) 
 		{
 			storage[i].damageItem(i, new EntityCowTFC(this.worldObj));
-			if(storage[i].stackSize == 0 || storage[i].getItemDamage() == storage[i].getMaxDamage())
+			if(storage[i].stackSize == 0 || storage[i].getItemDamage() == storage[i].getMaxDamage()) {
 				setInventorySlotContents(i, null);
+				TerraFirmaCraft.proxy.sendCustomPacketToPlayersInRange(xCoord, yCoord, zCoord, createUpdatePacket(), 160);
+			}
 		}
 	}
 	
@@ -237,7 +239,7 @@ public class TileEntityQuern extends NetworkTileEntity implements IInventory {
 		if(itemstack != null && itemstack.stackSize > getInventoryStackLimit()) {
 			itemstack.stackSize = getInventoryStackLimit();
 		}
-		TerraFirmaCraft.proxy.sendCustomPacketToPlayersInRange(xCoord, yCoord, zCoord, createUpdatePacket(), 160);
+		TerraFirmaCraft.proxy.sendCustomPacket(createUpdatePacket());
 	}
 
 	@Override
@@ -278,6 +280,7 @@ public class TileEntityQuern extends NetworkTileEntity implements IInventory {
 	@Override
 	public void handleDataPacket(DataInputStream inStream) throws IOException {
 		this.hasQuern = inStream.readBoolean();
+		this.shouldRotate = inStream.readBoolean();
 		worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
 	}
 
@@ -290,6 +293,7 @@ public class TileEntityQuern extends NetworkTileEntity implements IInventory {
 			dos.writeInt(yCoord);
 			dos.writeInt(zCoord);
 			dos.writeBoolean(storage[2] != null);
+			dos.writeBoolean(shouldRotate);
 		} catch (IOException e) {
 		}
 		return this.setupCustomPacketData(bos.toByteArray(), bos.size());


### PR DESCRIPTION
Right clicking to open quern container crashes the client.
Other players will also see the animation now.
