### PR TITLE
Fix standalone server crash and food level on player respawn...

### DIFF
--- a/TFC_Shared/src/TFC/Core/Player/PlayerTracker.java
+++ b/TFC_Shared/src/TFC/Core/Player/PlayerTracker.java
@@ -1,5 +1,7 @@
 package TFC.Core.Player;
 
+import TFC.Core.TFC_Core;
+import TFC.Food.FoodStatsTFC;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionEffect;
@@ -28,7 +30,10 @@ public class PlayerTracker implements IPlayerTracker
 	{
 		if(!player.worldObj.isRemote)
 		{
-			player.getFoodStats().setFoodLevel(player.worldObj.rand.nextInt(25)+35);
+			int foodLevel = (player.worldObj.rand.nextInt(25) + 35);
+			FoodStatsTFC foodstats = TFC_Core.getPlayerFoodStats(player);
+			foodstats.addStats(foodLevel - foodstats.getFoodLevel(), 0.0f);
+			TFC_Core.setPlayerFoodStats(player, foodstats);
 			player.setEntityHealth((int) (1000f*(((float)player.worldObj.rand.nextInt(25)+35)/100)));
 			player.addPotionEffect(new PotionEffect(Potion.moveSlowdown.id, 20*(player.worldObj.rand.nextInt(45)+45), 0));
 		}


### PR DESCRIPTION
after death. Food level is set between 35 and 60, which seems to be the original intent.
