### PR TITLE
Tweak snow cover

### DIFF
--- a/TFC_Shared/src/TFC/Blocks/Vanilla/BlockCustomIce.java
+++ b/TFC_Shared/src/TFC/Blocks/Vanilla/BlockCustomIce.java
@@ -39,8 +39,18 @@ public class BlockCustomIce extends BlockIce
     {
         if (!world.canBlockFreeze(i, j, k, false))
         {
-            this.dropBlockAsItem(world, i, j, k, world.getBlockMetadata(i, j, k), 0);
-            world.setBlock(i, j, k, Block.waterStill.blockID, 0, 2);
+            if (world.getBlockId(i, j+1, k) == Block.snow.blockID)
+            {
+            	int meta = world.getBlockMetadata(i, j+1, k);
+            	if (meta > 0) {
+            		world.setBlockMetadataWithNotify(i, j+1, k, meta-1, 2);
+            	} else {
+            		world.setBlockToAir(i, j+1, k);
+            	}
+            } else {
+            	this.dropBlockAsItem(world, i, j, k, world.getBlockMetadata(i, j, k), 0);
+            	world.setBlock(i, j, k, Block.waterStill.blockID, 0, 2);
+            }
         }
     }
 }

--- a/TFC_Shared/src/TFC/Blocks/Vanilla/BlockCustomSnow.java
+++ b/TFC_Shared/src/TFC/Blocks/Vanilla/BlockCustomSnow.java
@@ -1,7 +1,9 @@
 package TFC.Blocks.Vanilla;
 
+import java.io.Console;
 import java.util.Random;
 
+import scala.util.logging.ConsoleLogger;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IconRegister;
@@ -27,14 +29,17 @@ public class BlockCustomSnow extends BlockTerra
 		this.setTickRandomly(true);
 	}
 
-
 	@Override
 	public boolean canPlaceBlockAt(World par1World, int par2, int par3, int par4)
 	{
 		int var5 = par1World.getBlockId(par2, par3 - 1, par4);
-		return var5 != 0 && (var5 == Block.leaves.blockID || Block.blocksList[var5].isOpaqueCube()) ? true : false;
+		if (var5 == Block.ice.blockID
+				|| var5 != TFCBlocks.LooseRock.blockID
+				|| var5 == Block.leaves.blockID
+				|| Block.blocksList[var5].isOpaqueCube())
+			return true;
+		return false;
 	}
-
 	
 	private boolean canSnowStay(World par1World, int par2, int par3, int par4)
 	{
@@ -52,7 +57,9 @@ public class BlockCustomSnow extends BlockTerra
 	@Override
 	public AxisAlignedBB getCollisionBoundingBoxFromPool(World par1World, int par2, int par3, int par4)
 	{
-		return null;
+        int l = par1World.getBlockMetadata(par2, par3, par4) & 7;
+        float f = 0.125F;
+        return AxisAlignedBB.getAABBPool().getAABB((double)par2 + this.minX, (double)par3 + this.minY, (double)par4 + this.minZ, (double)par2 + this.maxX, (double)((float)par3 + (float)l * f), (double)par4 + this.maxZ);
 	}
 	@Override
 	public int getRenderType()
@@ -127,6 +134,10 @@ public class BlockCustomSnow extends BlockTerra
 	@Override
 	public void updateTick(World par1World, int par2, int par3, int par4, Random par5Random)
 	{
+		if (!this.canSnowStay(par1World, par2, par3, par4))
+		{
+			return;
+		}
 		int meta = par1World.getBlockMetadata(par2, par3, par4);
 		if (par1World.getSavedLightValue(EnumSkyBlock.Block, par2, par3, par4) > 11)
 		{
@@ -136,20 +147,25 @@ public class BlockCustomSnow extends BlockTerra
 				par1World.setBlockToAir(par2, par3, par4);
 			}
 		}
-		
 		if(par1World.isRaining() && TFC_Climate.getHeightAdjustedTemp(par2, par3, par4) <= 0)//Raining and Below Freezing
 		{      
 			if(meta < 3 && par1World.getBlockMaterial(par2, par3-1, par4) != Material.leaves) 
 			{
-				par1World.setBlockMetadataWithNotify(par2, par3, par4, meta+1, 2);
+				if (canAddSnow(par1World, par2, par3, par4, meta)) {
+					par1World.setBlockMetadataWithNotify(par2, par3, par4, meta+1, 2);
+				}
 			} 
 			else if(meta < 15 && par5Random.nextInt(8) == 0 && par1World.getBlockMaterial(par2, par3-1, par4) != Material.leaves)
             {
-                par1World.setBlockMetadataWithNotify(par2, par3, par4, meta+1, 2);
+				if (canAddSnow(par1World, par2, par3, par4, meta)) {
+					par1World.setBlockMetadataWithNotify(par2, par3, par4, meta+1, 2);
+				}
             }
 			else if(meta < 3 && par5Random.nextInt(3) == 0 && par1World.getBlockMaterial(par2, par3-1, par4) == Material.leaves)
 			{
-				par1World.setBlockMetadataWithNotify(par2, par3, par4, meta+1, 2);
+				if (canAddSnow(par1World, par2, par3, par4, meta)) {
+					par1World.setBlockMetadataWithNotify(par2, par3, par4, meta+1, 2);
+				}
 			}
 		}
 		else if(par1World.isRaining() && TFC_Climate.getHeightAdjustedTemp(par2, par3, par4) >= 0)//Raining and above freezing
@@ -176,23 +192,23 @@ public class BlockCustomSnow extends BlockTerra
         }
 		else if(TFC_Climate.getHeightAdjustedTemp(par2, par3, par4) >= 0F)//Above fReezing
 		{
-			if(meta > 1 ) {
+			if(meta > 0 ) {
 				par1World.setBlockMetadataWithNotify(par2, par3, par4, meta-1, 2);
-			} else if(meta == 1) {
+			} else {
 				par1World.setBlockToAir(par2, par3, par4);
 			}
 		}
-		else//Below Freezing
-		{
-		    if(meta > 1 && par5Random.nextInt(5) == 0) 
-		    {
-                par1World.setBlockMetadataWithNotify(par2, par3, par4, meta-1, 2);
-            } 
-		    else if(meta == 1 && par5Random.nextInt(5) == 0)
-            {
-                par1World.setBlockToAir(par2, par3, par4);
-            }
-		}
+//		else//Below Freezing
+//		{
+//		    if(meta > 1 && par5Random.nextInt(5) == 0)
+//		    {
+//              par1World.setBlockMetadataWithNotify(par2, par3, par4, meta-1, 2);
+//          }
+//		    else if(meta == 1 && par5Random.nextInt(5) == 0)
+//          {
+//          	par1World.setBlockToAir(par2, par3, par4);
+//          }
+//		}
 	}
 	
 	@Override
@@ -200,4 +216,41 @@ public class BlockCustomSnow extends BlockTerra
     {
 		this.blockIcon = registerer.registerIcon(Reference.ModID + ":"+"snow");
     }
+
+	private boolean canAddSnowCheckNeighbors(World world, int x, int y, int z, int meta)
+	{
+		if (!this.canPlaceBlockAt(world, x, y, z))
+		{
+			return true;
+		}
+		if (world.getBlockMaterial(x, y, z) != Material.snow) {
+			return false;
+		}
+		if ( world.getBlockMaterial(x, y, z) == Material.snow
+				&& meta > world.getBlockMetadata(x, y, z)) {
+			return false;
+		}
+		return true;
+	}
+
+	private boolean canAddSnow(World world, int x, int y, int z, int meta)
+	{
+		if (!canAddSnowCheckNeighbors(world, x+1, y, z, meta))
+		{
+			return false;
+		}
+		if (!canAddSnowCheckNeighbors(world, x-1, y, z, meta))
+		{
+			return false;
+		}
+		if (!canAddSnowCheckNeighbors(world, x, y, z+1, meta))
+		{
+			return false;
+		}
+		if (!canAddSnowCheckNeighbors(world, x, y, z-1, meta))
+		{
+			return false;
+		}
+		return true;
+	}
 }

--- a/TFC_Shared/src/TFC/WorldGen/TFCProvider.java
+++ b/TFC_Shared/src/TFC/WorldGen/TFCProvider.java
@@ -3,6 +3,7 @@ package TFC.WorldGen;
 import java.util.List;
 import java.util.Random;
 
+import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.ChunkCoordinates;
@@ -99,7 +100,7 @@ public class TFCProvider extends WorldProvider
 		{
 			biome = worldObj.getBiomeGenForCoordsBody(x, z);
 		}
-        if(canSnowAt(x,145,z)){biome.temperature = 0;}
+        if(canSnowAtTemp(x,145,z)){biome.temperature = 0;}
         else{biome.temperature = 0.16f;}
         return biome;
     }
@@ -166,10 +167,19 @@ public class TFCProvider extends WorldProvider
 			return true;
 		return false;
     }
-	@Override
+
+    @Override
     public boolean canSnowAt(int x, int y, int z)
     {
-    	if(TFC_Climate.getHeightAdjustedTemp(x, y, z) <= 0)
+    	if(TFC_Climate.getHeightAdjustedTemp(x, y, z) <= 0
+				&& Block.blocksList[Block.snow.blockID].canPlaceBlockAt(worldObj, x, y, z))
+			return true;
+		return false;
+    }
+
+    private boolean canSnowAtTemp(int x, int y, int z)
+    {
+		if(TFC_Climate.getHeightAdjustedTemp(x, y, z) <= 0)
 			return true;
 		return false;
     }


### PR DESCRIPTION
- Before adding an additional layer of snow the surrounding snow blocks are checked for a more equalized snow cover.
- There is no more floating snow cover generated above loose rocks.
- If a ice block is covered with snow and is checked for melting, the snow melts first before the ice melts.
