### PR TITLE
Fix melting ore in vessel slots 2-4. Should fix #167.

### DIFF
--- a/TFC_Shared/src/TFC/Items/Pottery/ItemPotterySmallVessel.java
+++ b/TFC_Shared/src/TFC/Items/Pottery/ItemPotterySmallVessel.java
@@ -156,18 +156,18 @@ public class ItemPotterySmallVessel extends ItemPotteryBase implements IBag
 			{
 				Metal m = null;
 				if(types[0] != null) m = types[0];
-				else if(types[1] != null) m = types[0];
-				else if(types[2] != null) m = types[0];
-				else if(types[3] != null) m = types[0];
+				else if(types[1] != null) m = types[1];
+				else if(types[2] != null) m = types[2];
+				else if(types[3] != null) m = types[3];
 
 				if(m != null)
 				{
 					NBTTagCompound tag = is.stackTagCompound;
 					tag.setString("MetalType", m.Name);
 					tag.setInteger("MetalAmount", total);
+					is.getTagCompound().removeTag("Items");
+					is.setItemDamage(2);
 				}
-				is.getTagCompound().removeTag("Items");
-				is.setItemDamage(2);
 			}
 		}
 	}


### PR DESCRIPTION
If metal was only in slots 2-4 a code typo caused it to use type[0] which was null, then the "Items" tag was removed anyway which creates a liquid vessel with no "MetalType" tag.
