### PR TITLE
Fixed jug crash.

### DIFF
--- a/TFC_Shared/src/TFC/Items/Pottery/ItemPotteryJug.java
+++ b/TFC_Shared/src/TFC/Items/Pottery/ItemPotteryJug.java
@@ -35,7 +35,7 @@ public class ItemPotteryJug extends ItemPotteryBase
             if (par1ItemStack.getItemDamage() > 1)
             {
             	if(par2World.rand.nextInt(25) == 0)
-            		par1ItemStack = null;
+            		par1ItemStack.stackSize--;
             	else
             	{
             		par1ItemStack.setItemDamage(1);


### PR DESCRIPTION
ItemPotteryJug.onEaten() was returning null when the jug was destroyed, but
the callers of onEaten() are not expecting null. Changed it to just
decrement the stack size instead.
