### PR TITLE
Fix problems with IAnimal.isInLove()

### DIFF
--- a/TFC API/TFC/API/Entities/IAnimal.java
+++ b/TFC API/TFC/API/Entities/IAnimal.java
@@ -26,7 +26,11 @@ public interface IAnimal
 
 	public boolean isPregnant();
 
-	public boolean isInLove();
+	//	It would be nice to call this isInLove() except that would shadow
+	//	EntityAnimal.isInLove() causing MCP to obfuscate this method, which
+	//	we don't want because the callers won't be obfuscated.
+	//	
+	public boolean getInLove();
 
 	public void setInLove(boolean b);
 

--- a/TFC_Shared/src/TFC/Entities/AI/EntityAIMateTFC.java
+++ b/TFC_Shared/src/TFC/Entities/AI/EntityAIMateTFC.java
@@ -33,7 +33,7 @@ public class EntityAIMateTFC extends EntityAIBase
 	@Override
 	public boolean shouldExecute ()
 	{
-		if (!theAnimal.isInLove())
+		if (!theAnimal.getInLove())
 		{
 			return false;
 		}
@@ -57,7 +57,7 @@ public class EntityAIMateTFC extends EntityAIBase
 	@Override
 	public boolean continueExecuting ()
 	{
-		return targetMate.getEntity().isEntityAlive() && targetMate.isInLove() && matingCounter < 60 && 
+		return targetMate.getEntity().isEntityAlive() && targetMate.getInLove() && matingCounter < 60 && 
 				((targetMate.getGender() == GenderEnum.FEMALE && theAnimal.getGender() == GenderEnum.MALE) || 
 						(targetMate.getGender() == GenderEnum.MALE && theAnimal.getGender() == GenderEnum.FEMALE));
 	}

--- a/TFC_Shared/src/TFC/Entities/Mobs/EntityBear.java
+++ b/TFC_Shared/src/TFC/Entities/Mobs/EntityBear.java
@@ -334,7 +334,7 @@ public class EntityBear extends EntityTameable implements ICausesDamage, IAnimal
 			return false;
 		}
 		EntityBear entitybear = (EntityBear) par1EntityAnimal;
-		return isInLove () && entitybear.isInLove ();
+		return getInLove () && entitybear.getInLove ();
 	}
 
 	@Override
@@ -414,6 +414,12 @@ public class EntityBear extends EntityTameable implements ICausesDamage, IAnimal
 		resetInLove();
 		otherAnimal.setInLove(false);
 		mateSizeMod = otherAnimal.getSize();
+	}
+
+	@Override
+	public boolean getInLove()
+	{
+		return inLove;
 	}
 
 	@Override

--- a/TFC_Shared/src/TFC/Entities/Mobs/EntityChickenTFC.java
+++ b/TFC_Shared/src/TFC/Entities/Mobs/EntityChickenTFC.java
@@ -262,6 +262,12 @@ public class EntityChickenTFC extends EntityChicken implements IAnimal
 	}
 
 	@Override
+	public boolean getInLove()
+	{
+		return inLove;
+	}
+
+	@Override
 	public void setInLove(boolean b) 
 	{
 		this.inLove = b;

--- a/TFC_Shared/src/TFC/Entities/Mobs/EntityCowTFC.java
+++ b/TFC_Shared/src/TFC/Entities/Mobs/EntityCowTFC.java
@@ -296,6 +296,12 @@ public class EntityCowTFC extends EntityCow implements IAnimal
 	}
 
 	@Override
+	public boolean getInLove()
+	{
+		return inLove;
+	}
+
+	@Override
 	public void setInLove(boolean b) 
 	{
 		this.inLove = b;

--- a/TFC_Shared/src/TFC/Entities/Mobs/EntityDeer.java
+++ b/TFC_Shared/src/TFC/Entities/Mobs/EntityDeer.java
@@ -342,6 +342,12 @@ public class EntityDeer extends EntityAnimal implements IAnimal
 	}
 
 	@Override
+	public boolean getInLove()
+	{
+		return inLove;
+	}
+
+	@Override
 	public void setInLove(boolean b) 
 	{
 		this.inLove = b;

--- a/TFC_Shared/src/TFC/Entities/Mobs/EntityPigTFC.java
+++ b/TFC_Shared/src/TFC/Entities/Mobs/EntityPigTFC.java
@@ -382,6 +382,12 @@ public class EntityPigTFC extends EntityPig implements IAnimal
 	}
 
 	@Override
+	public boolean getInLove()
+	{
+		return inLove;
+	}
+
+	@Override
 	public void setInLove(boolean b) 
 	{
 		this.inLove = b;

--- a/TFC_Shared/src/TFC/Entities/Mobs/EntitySheepTFC.java
+++ b/TFC_Shared/src/TFC/Entities/Mobs/EntitySheepTFC.java
@@ -346,6 +346,12 @@ public class EntitySheepTFC extends EntitySheep implements IShearable, IAnimal
 	}
 
 	@Override
+	public boolean getInLove()
+	{
+		return inLove;
+	}
+
+	@Override
 	public void setInLove(boolean b) 
 	{
 		this.inLove = b;

--- a/TFC_Shared/src/TFC/Entities/Mobs/EntityWolfTFC.java
+++ b/TFC_Shared/src/TFC/Entities/Mobs/EntityWolfTFC.java
@@ -277,7 +277,7 @@ public class EntityWolfTFC extends EntityWolf implements IAnimal
 		else
 		{
 			EntityWolfTFC var2 = (EntityWolfTFC)par1EntityAnimal;
-			return !var2.isTamed() ? false : (var2.isSitting() ? false : this.isInLove() && var2.isInLove());
+			return !var2.isTamed() ? false : (var2.isSitting() ? false : this.getInLove() && var2.getInLove());
 		}
 	}
 	@Override
@@ -352,6 +352,12 @@ public class EntityWolfTFC extends EntityWolf implements IAnimal
 		resetInLove();
 		otherAnimal.setInLove(false);
 		mateSizeMod = otherAnimal.getSize();
+	}
+
+	@Override
+	public boolean getInLove()
+	{
+		return inLove;
 	}
 
 	@Override


### PR DESCRIPTION
1) The IAnimal interface defines the isInLove() method but none of the animals
which implement the interface were providing an implementation for it.
Since they all also derive from EntityAnimal, they were picking up its
isInLove() method, which won't work. So I added isInLove() methods to all
of the classes which implement IAnimal.

2) Since all of the animals which implement IAnimal also derive from
EntityAnimal, IAnimal.isInLove() was shadowing EntityAnimal.isInLove().
This resulting in MCP obfuscating the former (a bug in MCP?). However the
callers of IAnimal.isInLove() were not being similarly obfuscated, leading
to AbstractMethod exceptions in the obfuscated binary.

To fix that I changed the name of IAnimal.isInLove() to
IAnimal.getInLove().
