### PR TITLE
Fix vanilla items with TFC tags crashing when compared to those w/o tags...

### DIFF
--- a/TFC_Shared/src/TFC/Containers/ContainerTFC.java
+++ b/TFC_Shared/src/TFC/Containers/ContainerTFC.java
@@ -5,6 +5,7 @@ import net.minecraft.inventory.Container;
 import net.minecraft.inventory.ICrafting;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
 
 public class ContainerTFC extends Container
 {
@@ -167,17 +168,25 @@ public class ContainerTFC extends Container
 	{
 		ItemStack is3 = is1.copy(); 
 		ItemStack is4 = is2.copy(); 
-		float temp3 = is3.getTagCompound().hasKey("temperature") ? is3.getTagCompound().getFloat("temperature") : -1000;
-		float temp4 = is4.getTagCompound().hasKey("temperature") ? is4.getTagCompound().getFloat("temperature") : -1000;
-		is3.getTagCompound().removeTag("temperature");
-		is4.getTagCompound().removeTag("temperature");
 
-		boolean isBaseEqual = is3.getTagCompound().equals(is4.getTagCompound());
+		NBTTagCompound is3Tags = is3.getTagCompound();
+		NBTTagCompound is4Tags = is4.getTagCompound();
 
-		if(isBaseEqual && ((temp3 - temp4) < 5 || (temp3 - temp4) > -5)) {
-			return true;
+		if (is3Tags == null)
+		{
+			return (is4Tags == null) || is4Tags.hasNoTags();
 		}
 
-		return false;
+		if (is4Tags == null)
+		{
+			return is3Tags.hasNoTags();
+		}
+
+		float temp3 = is3Tags.hasKey("temperature") ? is3Tags.getFloat("temperature") : -1000;
+		float temp4 = is4Tags.hasKey("temperature") ? is4Tags.getFloat("temperature") : -1000;
+		is3Tags.removeTag("temperature");
+		is4Tags.removeTag("temperature");
+
+		return is3Tags.equals(is4Tags) &&  (((temp3 - temp4) < 5) || ((temp3 - temp4) > -5));
 	}
 }


### PR DESCRIPTION
....

Check that the item's NBTTagCompound is not null before trying to call its
methods.
