### PR TITLE
Fix crash for BiomeEventHandler and GUIInGameForge.

### DIFF
--- a/TFC_Shared/src/TFC/ClientProxy.java
+++ b/TFC_Shared/src/TFC/ClientProxy.java
@@ -24,6 +24,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
+import net.minecraftforge.client.GuiIngameForge;
 import net.minecraftforge.common.MinecraftForge;
 import TFC.API.Enums.EnumTree;
 import TFC.Core.ColorizerFoliageTFC;
@@ -75,6 +76,7 @@ import TFC.GUI.GuiSluice;
 import TFC.GUI.GuiVessel;
 import TFC.GUI.GuiVesselLiquid;
 import TFC.GUI.GuiWorkbench;
+import TFC.Handlers.BiomeEventHandler;
 import TFC.Handlers.Client.BlockRenderHandler;
 import TFC.Handlers.Client.ChiselHighlightHandler;
 import TFC.Handlers.Client.FarmlandHighlightHandler;
@@ -214,6 +216,23 @@ public class ClientProxy extends CommonProxy
 
 		//Register our overlay changes
 		MinecraftForge.EVENT_BUS.register(new RenderOverlayHandler());
+	}
+	
+	@Override
+	@SideOnly(Side.CLIENT)
+	public void registerBiomeEventHandler()
+	{
+		// Register the Biome Event Handler
+		MinecraftForge.EVENT_BUS.register(new BiomeEventHandler());
+	}
+	
+	@Override
+	@SideOnly(Side.CLIENT)
+	public void setupGuiIngameForge()
+	{
+		GuiIngameForge.renderHealth = false;
+		GuiIngameForge.renderArmor = false;
+		GuiIngameForge.renderFood = false;
 	}
 
 	@Override

--- a/TFC_Shared/src/TFC/CommonProxy.java
+++ b/TFC_Shared/src/TFC/CommonProxy.java
@@ -57,6 +57,7 @@ import TFC.Entities.Mobs.EntitySpiderTFC;
 import TFC.Entities.Mobs.EntitySquidTFC;
 import TFC.Entities.Mobs.EntityWolfTFC;
 import TFC.Entities.Mobs.EntityZombieTFC;
+import TFC.Handlers.BiomeEventHandler;
 import TFC.TileEntities.TEBlastFurnace;
 import TFC.TileEntities.TECrucible;
 import TFC.TileEntities.TileEntityAnvil;
@@ -94,6 +95,16 @@ public class CommonProxy implements IGuiHandler
 {
 
 	public void registerRenderInformation() {
+		// NOOP on server
+	}
+	
+	public void registerBiomeEventHandler()
+	{
+		// NOOP on server
+	}
+	
+	public void setupGuiIngameForge()
+	{
 		// NOOP on server
 	}
 

--- a/TFC_Shared/src/TFC/TerraFirmaCraft.java
+++ b/TFC_Shared/src/TFC/TerraFirmaCraft.java
@@ -121,10 +121,6 @@ public class TerraFirmaCraft
 	@EventHandler
 	public void initialize(FMLInitializationEvent evt)
 	{
-		GuiIngameForge.renderHealth = false;
-		GuiIngameForge.renderArmor = false;
-		GuiIngameForge.renderFood = false;
-
 		//Add Item Name Localizations
 		Localization.addLocalization("/assets/terrafirmacraft/lang/", "en_US");
 		//LanguageRegistry.instance().loadLocalization("assets/terrafirmacraft/lang/", "en_US", false);
@@ -174,9 +170,10 @@ public class TerraFirmaCraft
 
 		//Register our player tracker
 		GameRegistry.registerPlayerTracker(new PlayerTracker());
-
-		// Register the Biome Event Handler
-		MinecraftForge.EVENT_BUS.register(new BiomeEventHandler());
+		
+		proxy.registerBiomeEventHandler();
+		
+		proxy.setupGuiIngameForge();
 
 		//Setup custom potion effects
 		TFCPotion.Setup();


### PR DESCRIPTION
They should be registered client side only so in the ClientProxy only.

Closes #190
