### PR TITLE
Fix for missing ingot pile textures.

### DIFF
--- a/TFC_Shared/src/TFC/Render/TileEntityIngotPileRenderer.java
+++ b/TFC_Shared/src/TFC/Render/TileEntityIngotPileRenderer.java
@@ -38,7 +38,7 @@ public class TileEntityIngotPileRenderer extends TileEntitySpecialRenderer
 			if (par1TileEntityPile.getStackInSlot(0)!=null)
 			{
 				int i = ((TFC.Blocks.BlockIngotPile)var10).getStack(par1TileEntityPile.worldObj,par1TileEntityPile);
-				ModLoader.getMinecraftInstance().renderEngine.func_110577_a(new ResourceLocation(Reference.ModID, "/textures/blocks/metal/"+par1TileEntityPile.type+".png")); //texture
+				ModLoader.getMinecraftInstance().renderEngine.func_110577_a(new ResourceLocation(Reference.ModID, "textures/blocks/metal/"+par1TileEntityPile.type+".png")); //texture
 				GL11.glPushMatrix(); //start
 				GL11.glTranslatef((float)d + 0.0F, (float)d1 + 0F, (float)d2 + 0.0F); //size
 


### PR DESCRIPTION
Removed the '/' in the texture path in the ingot pile rendering code. Fixes the issue of missing texture I was getting.
