### PR TITLE
Fix bugs in release scripts.

### DIFF
--- a/build.py
+++ b/build.py
@@ -25,10 +25,10 @@ def build(build_num=0):
     print '=================================== Build Start ================================='   
     print '\nsrc -> backup'
     copytree(src_dir, backup_dir, 0)    
-    print '\ntfc_shared -> minecraft'
-    copytree(os.path.join(forge_dir, 'tfc_shared'), os.path.join(src_dir, 'minecraft'), 0)
-    print '\ntfc api -> minecraft'
-    copytree(os.path.join(forge_dir, 'tfc api'), os.path.join(src_dir, 'minecraft'), 0)
+    print '\nTFC_Shared -> minecraft'
+    copytree(os.path.join(forge_dir, 'TFC_Shared'), os.path.join(src_dir, 'minecraft'), 0)
+    print '\nTFC API -> minecraft'
+    copytree(os.path.join(forge_dir, 'TFC API'), os.path.join(src_dir, 'minecraft'), 0)
     print
     
     error_level = 0

--- a/release.py
+++ b/release.py
@@ -49,7 +49,7 @@ def main():
     
     version = load_version(build_num)
         
-    out_folder = os.path.join(forge_dir, 'TFC Build')
+    out_folder = os.path.join(mcp_dir, 'TFC Build')
     if os.path.isdir(out_folder):
         shutil.rmtree(out_folder)
         


### PR DESCRIPTION
Corrected the case on several filenames to match their case in git, so that
the scripts will work on case-sensitive file systems.

In release.py main() was creating 'forge/mcp/TFCraft/TFC Build' while
zip_start was expecting 'forge/mcp/TFC Build'. Fixed the former to use the
same path as the latter.
