### PR TITLE
Largely refactored onItemUse

### DIFF
--- a/TFC_Shared/src/TFC/Items/Tools/ItemProPick.java
+++ b/TFC_Shared/src/TFC/Items/Tools/ItemProPick.java
@@ -1,7 +1,6 @@
 package TFC.Items.Tools;
 
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Random;
 
 import net.minecraft.client.renderer.texture.IconRegister;
@@ -15,10 +14,23 @@ import TFC.API.Enums.EnumSize;
 import TFC.API.Enums.EnumWeight;
 import TFC.API.Util.StringUtil;
 import TFC.Items.ItemTerra;
+import java.util.HashMap;
 
 public class ItemProPick extends ItemTerra
 {
-    List vecArray;
+    private class ProspectResult {
+        public ItemStack ItemStack;
+        public int Count;
+        
+        public ProspectResult(ItemStack itemStack, int count) {
+            ItemStack = itemStack;
+            Count = count;
+        }
+    }
+    
+    HashMap<Integer, ProspectResult> results =
+            new HashMap<Integer, ProspectResult>();
+    Random random = null;
 
     public ItemProPick(int i) 
     {
@@ -32,161 +44,133 @@ public class ItemProPick extends ItemTerra
     {
     	this.itemIcon = registerer.registerIcon(Reference.ModID + ":" + "tools/"+this.getUnlocalizedName().replace("item.", ""));
     }
-
+    
     @Override
-    public boolean onItemUse(ItemStack itemstack, EntityPlayer entityplayer, World world, int x, int y, int z, int side, float HitX, float HitY, float HitZ) 
-    {
-        if(world.isRemote && world.getBlockId(x, y, z) != TFCBlocks.ToolRack.blockID)
-        {
-//        	Random rand = new Random(x*z+y);
-//        	ChunkData data = ChunkDataManager.getData(x >> 4, z >> 4);
-//        	
-//        	int currentLayer = y < TerraFirmaCraft.RockLayer3Height ? 3 : y < TerraFirmaCraft.RockLayer2Height ? 2 : 1;
-//        	
-//        	if(currentLayer == 1)
-//        	{
-//        		if(data.oreList1.size() > 0)
-//        		{
-//        			String Ore = data.oreList1.get(rand.nextInt(data.oreList1.size()));
-//        			MessageQue.instance.addMessage("Ore");
-//        		}
-//        	}
-        	
-        	
-            ArrayList oreArray = new ArrayList<String>();
-            ArrayList oreNumArray = new ArrayList<Integer>();
+    public boolean onItemUse(ItemStack itemStack, EntityPlayer player, World world, int x, int y, int z, int side, float hitX, float hitY, float hitZ) {
+        int blockID = world.getBlockId(x, y, z);
+        
+        // Negated the old condition and exiting the method here instead.
+        if (blockID == TFCBlocks.ToolRack.blockID)
+            return true;
+        
+        // Getting the meta data only when we actually need it.
+        int meta = world.getBlockMetadata(x, y, z);
+        
+        // Damage the item on prospecting use.
+        if (!world.isRemote) {
+            itemStack.damageItem(1, player);
+            if (itemStack.getItemDamage() >= itemStack.getMaxDamage())
+                player.destroyCurrentEquippedItem();
             
-            boolean isOre = false;
+            return true;
+        }
+        
+        // If an ore block is targeted directly, it'll tell you what it is.
+        if (blockID == TFCBlocks.Ore.blockID ||
+                blockID == TFCBlocks.Ore2.blockID ||
+                blockID == TFCBlocks.Ore3.blockID) {
             
-            int id = world.getBlockId(x, y, z);
-            int meta = world.getBlockMetadata(x, y, z);
-            if(id == TFCBlocks.Ore.blockID)
-            {
-                isOre = true;
-                
-                oreArray.add(new ItemStack(id,1,meta).getItem().getItemDisplayName(new ItemStack(id,1,meta)));
-            }
-            else if(id == TFCBlocks.Ore2.blockID)
-            {
-                isOre = true;
-                oreArray.add(new ItemStack(id,1,meta).getItem().getItemDisplayName(new ItemStack(id,1,meta)));
-            }
-            else if(id == TFCBlocks.Ore3.blockID)
-            {
-                isOre = true;
-                oreArray.add(new ItemStack(id,1,meta).getItem().getItemDisplayName(new ItemStack(id,1,meta)));
-            }
-            //sides XN(0), XP(1), YN(2), YP(3), ZN(4), ZP(5);          
-            for (int i = -12; i < 12 && !isOre; i++)
-            {
-                for (int j = -12; j < 12; j++)
-                {
-                    for (int k = -12; k < 12; k++)
-                    {
-                    	meta = world.getBlockMetadata(x+i, y+k, z+j);
-                        int oreid = world.getBlockId(x+i, y+k, z+j);
-
-                        
-                        if(oreid == TFCBlocks.Ore.blockID)
-                        {                   
-                        	ItemStack is = new ItemStack(oreid,1,meta);
-                            String itemName = is.getItem().getItemDisplayName(is);
-                            if(!oreArray.contains(itemName))
-                            {
-                                oreArray.add(itemName);
-                                oreNumArray.add(1);
-                            }
-                            else
-                            {
-                                int index = oreArray.indexOf(itemName);
-                                oreNumArray.set(index, (Integer)oreNumArray.toArray()[index]+1);
-                            }
-
-
-                        }
-                        else if(oreid == TFCBlocks.Ore2.blockID)
-                        {
-                        	ItemStack is = new ItemStack(oreid,1,meta);
-                            String itemName = is.getItem().getItemDisplayName(is);
-                            if(meta != 6)
-                            {
-                                if(!oreArray.contains(itemName))
-                                {
-                                    oreArray.add(itemName);
-                                    oreNumArray.add(1);
-                                }
-                                else
-                                {
-                                    int index = oreArray.indexOf(itemName);
-                                    oreNumArray.set(index, (Integer)oreNumArray.toArray()[index]+1);
-                                }
-                            }
-                        }
-                        else if(oreid == TFCBlocks.Ore3.blockID)
-                        {
-                        	ItemStack is = new ItemStack(oreid,1,meta);
-                            String itemName = is.getItem().getItemDisplayName(is);
-                            if(!oreArray.contains(itemName))
-                            {
-                                oreArray.add(itemName);
-                                oreNumArray.add(1);
-                            }
-                            else
-                            {
-                                int index = oreArray.indexOf(itemName);
-                                oreNumArray.set(index, (Integer)oreNumArray.toArray()[index]+1);
-                            }
-                        }
+            TellResult(player, new ItemStack(blockID, 1, meta));
+            return true;
+        }
+        
+        random = new Random(x * z + y);
+        
+        // If random(100) is less than 60, it used to succeed. we don't need to
+        // gather the blocks in a 25x25 area if it doesn't.
+        if (random.nextInt(100) >= 60) {
+            player.addChatMessage(StringUtil.localize("gui.ProPick.FoundNothing"));
+            return true;
+        }
+        
+        // Check all blocks in the 25x25 area, centered on the targeted block.
+        for (int i = -12; i < 12; i++) {
+            for (int j = -12; j < 12; j++) {
+                for(int k = -12; k < 12; k++) {
+                    int blockX = x + i, 
+                            blockY = y + j,
+                            blockZ = z + k;
+                    
+                    blockID = world.getBlockId(blockX, blockY, blockZ);
+                    
+                    if (blockID != TFCBlocks.Ore.blockID &&
+                            blockID != TFCBlocks.Ore2.blockID &&
+                            blockID != TFCBlocks.Ore3.blockID)
+                        continue;
+                    
+                    if (results.containsKey(blockID))
+                        results.get(blockID).Count++;
+                    else {
+                        meta = world.getBlockMetadata(blockX, blockY, blockZ);
+                        ItemStack ore = new ItemStack(blockID, 1, meta);
+                        results.put(blockID, new ProspectResult(ore, 1));
+                        ore = null;
                     }
                 }
             }
-
-            Random random = new Random((x*z)+y);
-            if(oreArray.toArray().length > 0 && !isOre && random.nextInt(100) < 60)
-            {
-                int rand = random.nextInt(oreArray.toArray().length);
-                if((Integer)oreNumArray.toArray()[rand] < 10) {
-                    entityplayer.addChatMessage(StringUtil.localize("gui.ProPick.FoundTraces") + " " + oreArray.toArray()[rand]);
-                } else if((Integer)oreNumArray.toArray()[rand] < 20) {
-                    entityplayer.addChatMessage(StringUtil.localize("gui.ProPick.FoundSmall") + " " + oreArray.toArray()[rand]);
-                } else if((Integer)oreNumArray.toArray()[rand] < 40) {
-                    entityplayer.addChatMessage(StringUtil.localize("gui.ProPick.FoundMedium") + " " + oreArray.toArray()[rand]);
-                } else if((Integer)oreNumArray.toArray()[rand] < 80) {
-                    entityplayer.addChatMessage(StringUtil.localize("gui.ProPick.FoundLarge") + " " + oreArray.toArray()[rand]);
-                } else {
-                    entityplayer.addChatMessage(StringUtil.localize("gui.ProPick.FoundVeryLarge") + " " + oreArray.toArray()[rand]);
-                }
-            }
-            else if(isOre)
-            {
-                entityplayer.addChatMessage(StringUtil.localize("gui.ProPick.Found") + " " + oreArray.toArray()[0]);
-            }
-            else 
-            {
-                entityplayer.addChatMessage(StringUtil.localize("gui.ProPick.FoundNothing"));
-            }
         }
-        itemstack.setItemDamage(itemstack.getItemDamage()+1);
-        if(itemstack.getItemDamage() >= itemstack.getMaxDamage())
-            itemstack.stackSize = 0;
+        
+        // Tell the player what was found.
+        TellResult(player);
+        
+        results.clear();
+        random = null;
+        
         return true;
     }
     
+    /*
+     * Tells the player what block of ore he found, when directly targeting an ore block.
+     */
+    private void TellResult(EntityPlayer player, ItemStack ore) {
+        player.addChatMessage(String.format("%s %s", 
+                StringUtil.localize("gui.ProPick.Found"), 
+                ore.getItem().getItemDisplayName(ore)));
+    }
+    
+    /*
+     * Tells the player what ore has been found, randomly picked off the HashMap.
+     */
+    private void TellResult(EntityPlayer player) {
+        if (results == null || results.size() == 0) {
+            player.addChatMessage(StringUtil.localize("gui.ProPick.FoundNothing"));
+            return;
+        }
+        
+        int index = random.nextInt(results.size());
+        ProspectResult result = results.values().toArray(new ProspectResult[0])[index];
+        String oreName = result.ItemStack.getItem().getItemDisplayName(result.ItemStack);
+        
+        if (result.Count < 10)
+            player.addChatMessage(String.format("%s %s", StringUtil.localize("gui.ProPick.FoundTraces"), oreName));
+        else if(result.Count < 20)
+            player.addChatMessage(String.format("%s %s", StringUtil.localize("gui.ProPick.FoundSmall"), oreName));
+        else if (result.Count < 40)
+            player.addChatMessage(String.format("%s %s", StringUtil.localize("gui.ProPick.FoundMedium"), oreName));
+        else if (result.Count < 80)
+            player.addChatMessage(String.format("%s %s", StringUtil.localize("gui.ProPick.FoundLarge"), oreName));
+        else
+            player.addChatMessage(String.format("%s %s", StringUtil.localize("gui.ProPick.FoundVeryLarge"), oreName));
+        
+        oreName = null;
+        result = null;
+    }
+    
     @Override
-	public EnumSize getSize() {
-		// TODO Auto-generated method stub
-		return EnumSize.SMALL;
-	}
+    public EnumSize getSize() {
+            // TODO Auto-generated method stub
+            return EnumSize.SMALL;
+    }
 
-	@Override
-	public boolean canStack() {
-		// TODO Auto-generated method stub
-		return false;
-	}
-	
-	@Override
-	public EnumWeight getWeight() {
-		// TODO Auto-generated method stub
-		return EnumWeight.LIGHT;
-	}
+    @Override
+    public boolean canStack() {
+            // TODO Auto-generated method stub
+            return false;
+    }
+
+    @Override
+    public EnumWeight getWeight() {
+            // TODO Auto-generated method stub
+            return EnumWeight.LIGHT;
+    }
 }


### PR DESCRIPTION
Encapsulated prospecting results. Used one hash map instead of two array lists. Avoided creating large numbers of needless ItemStack instances. Avoided running code that doesn't have to, e.g. when false negatives are shown. Moved chat messages to their own methods. Preserving the original mechanic. Simple time profiling shows it's considerably faster now, too. Possibly much more memory efficient as well.
