### PR TITLE
Largely refactored onItemUse

### DIFF
--- a/TFC_Shared/src/TFC/Items/Tools/ItemProPick.java
+++ b/TFC_Shared/src/TFC/Items/Tools/ItemProPick.java
@@ -1,6 +1,5 @@
 package TFC.Items.Tools;
 
-import java.util.ArrayList;
 import java.util.Random;
 
 import net.minecraft.client.renderer.texture.IconRegister;
@@ -28,8 +27,8 @@ public class ItemProPick extends ItemTerra
         }
     }
     
-    HashMap<Integer, ProspectResult> results =
-            new HashMap<Integer, ProspectResult>();
+    HashMap<String, ProspectResult> results =
+            new HashMap<String, ProspectResult>();
     Random random = null;
 
     public ItemProPick(int i) 
@@ -98,14 +97,17 @@ public class ItemProPick extends ItemTerra
                             blockID != TFCBlocks.Ore3.blockID)
                         continue;
                     
-                    if (results.containsKey(blockID))
-                        results.get(blockID).Count++;
-                    else {
-                        meta = world.getBlockMetadata(blockX, blockY, blockZ);
-                        ItemStack ore = new ItemStack(blockID, 1, meta);
-                        results.put(blockID, new ProspectResult(ore, 1));
-                        ore = null;
-                    }
+                    meta = world.getBlockMetadata(blockX, blockY, blockZ);
+                    ItemStack ore = new ItemStack(blockID, 1, meta);
+                    String oreName = ore.getDisplayName();
+                    
+                    if (results.containsKey(oreName))
+                        results.get(oreName).Count++;
+                    else
+                        results.put(oreName, new ProspectResult(ore, 1));
+                    
+                    ore = null;
+                    oreName = null;
                 }
             }
         }


### PR DESCRIPTION
Encapsulated prospecting results. Used one hash map instead of two array lists. Avoided creating large numbers of needless ItemStack instances. Avoided running code that doesn't have to, e.g. when false negatives are shown. Moved chat messages to their own methods. Preserving the original mechanic. Simple time profiling shows it's considerably faster now, too. Possibly much more memory efficient as well. Fixed the overlooked issue with the hash map key.
On IRC my nickname is jackd`23`.
