### PR TITLE
Fixed a condition I had overlooked, not excluding petrified wood from prospecting. ProPick now doesn't take damage in creative mode. Now prospects a 25 cubic blocks area instead of only 24.

### DIFF
--- a/TFC_Shared/src/TFC/Items/Tools/ItemProPick.java
+++ b/TFC_Shared/src/TFC/Items/Tools/ItemProPick.java
@@ -86,9 +86,9 @@ public class ItemProPick extends ItemTerra
         }
         
         // Check all blocks in the 25x25 area, centered on the targeted block.
-        for (int i = -12; i < 12; i++) {
-            for (int j = -12; j < 12; j++) {
-                for(int k = -12; k < 12; k++) {
+        for (int i = -12; i <= 12; i++) {
+            for (int j = -12; j <= 12; j++) {
+                for(int k = -12; k <= 12; k++) {
                     int blockX = x + i, 
                             blockY = y + j,
                             blockZ = z + k;


### PR DESCRIPTION
I've overlooked that Ore2 with Meta value 6 (petrified wood) was excluded from being prospected and added the exclusion back in. The pick will now also not take damage while in creative mode. The original for-loops iterating through all blocks from -12 to <12 (+11) relative to the targeted block coordinate would only gather a 24x24x24 area instead of 25.
