### PR TITLE
Move items in creative tab

### DIFF
--- a/TFC_Shared/src/TFC/Items/ItemClay.java
+++ b/TFC_Shared/src/TFC/Items/ItemClay.java
@@ -21,7 +21,7 @@ public class ItemClay extends ItemLooseRock
 	public ItemClay(int id) 
 	{
 		super(id);
-		this.setCreativeTab(CreativeTabs.tabMaterials);
+		this.setCreativeTab(TFCTabs.TFCPottery);
 		this.icons = new Icon[2];
 	}
 

--- a/TFC_Shared/src/TFC/Items/ItemLeather.java
+++ b/TFC_Shared/src/TFC/Items/ItemLeather.java
@@ -22,7 +22,7 @@ public class ItemLeather extends ItemLooseRock
 	public ItemLeather(int id) 
 	{
 		super(id);
-		this.setCreativeTab(CreativeTabs.tabMaterials);
+		this.setCreativeTab(TFCTabs.TFCMaterials);
 		this.MetaNames = null;
 	}
 

--- a/TFC_Shared/src/TFC/Items/ItemLooseRock.java
+++ b/TFC_Shared/src/TFC/Items/ItemLooseRock.java
@@ -28,7 +28,7 @@ public class ItemLooseRock extends ItemTerra
 		super(id);
 		this.hasSubtypes = true;
 		this.setMaxDamage(0);
-		this.setCreativeTab(CreativeTabs.tabMaterials);
+		this.setCreativeTab(TFCTabs.TFCMaterials);
 		this.MetaNames = Global.STONE_ALL;
 		icons = new Icon[MetaNames.length];
 	}

--- a/TFC_Shared/src/TFC/Items/ItemMetalSheet.java
+++ b/TFC_Shared/src/TFC/Items/ItemMetalSheet.java
@@ -45,7 +45,7 @@ public class ItemMetalSheet extends ItemTerra
 	{
 		super(i);
 		setMaxDamage(0);
-		this.setCreativeTab(CreativeTabs.tabMaterials);
+		this.setCreativeTab(TFCTabs.TFCMaterials);
 		setFolder("ingots/");
 	}
 

--- a/TFC_Shared/src/TFC/Items/ItemMetalSheet2x.java
+++ b/TFC_Shared/src/TFC/Items/ItemMetalSheet2x.java
@@ -45,7 +45,7 @@ public class ItemMetalSheet2x extends ItemMetalSheet
 	{
 		super(i);
 		setMaxDamage(0);
-		this.setCreativeTab(CreativeTabs.tabMaterials);
+		this.setCreativeTab(TFCTabs.TFCMaterials);
 	}
 
 	@Override

--- a/TFC_Shared/src/TFC/Items/ItemWoolYarn.java
+++ b/TFC_Shared/src/TFC/Items/ItemWoolYarn.java
@@ -12,7 +12,7 @@ public class ItemWoolYarn extends ItemTerra
 		super(id);
 		this.hasSubtypes = false;
 		this.setMaxDamage(0);
-		this.setCreativeTab(CreativeTabs.tabMaterials);
+		this.setCreativeTab(TFCTabs.TFCMaterials);
 	}	
 
 	@Override

--- a/TFC_Shared/src/TFC/TFCItems.java
+++ b/TFC_Shared/src/TFC/TFCItems.java
@@ -1439,7 +1439,7 @@ public class TFCItems
 
 		Blueprint = new ItemBlueprint(TFCItemID.Blueprint);
 		writabeBookTFC = new ItemWritableBookTFC(TFCItemID.WritableBookTFC,"Fix Me I'm Broken").setUnlocalizedName("book");
-		WoolYarn = new ItemTerra(TFCItemID.WoolYarn).setUnlocalizedName("WoolYarn").setCreativeTab(TFCTabs.TFCMaterials);
+		WoolYarn = new ItemTerra(TFCItemID.WoolYarn).setUnlocalizedName("WoolYarn");
 		Wool = new ItemTerra(TFCItemID.Wool).setUnlocalizedName("Wool").setCreativeTab(TFCTabs.TFCMaterials);
 		WoolCloth = new ItemTerra(TFCItemID.WoolCloth).setUnlocalizedName("WoolCloth").setCreativeTab(TFCTabs.TFCMaterials);
 		Spindle = new ItemSpindle(TFCItemID.Spindle).setUnlocalizedName("Spindle").setCreativeTab(TFCTabs.TFCMaterials);
@@ -1458,7 +1458,7 @@ public class TFCItems
 		muttonRaw = new ItemTerra(TFCItemID.muttonRaw).setFolder("food/").setUnlocalizedName("Mutton Raw");
 		muttonCooked =  new ItemTerraFood(TFCItemID.muttonCooked, 40, 0.8F, true, 48).setUnlocalizedName("Mutton Cooked");
 		FlatLeather = (new ItemFlatGeneric(TFCItemID.FlatLeather2).setFolder("tools/").setUnlocalizedName("Flat Leather"));
-		TerraLeather = new ItemLeather(TFCItemID.TFCLeather).setSpecialCraftingType(FlatLeather).setFolder("tools/").setUnlocalizedName("TFC Leather").setCreativeTab(TFCTabs.TFCMaterials);
+		TerraLeather = new ItemLeather(TFCItemID.TFCLeather).setSpecialCraftingType(FlatLeather).setFolder("tools/").setUnlocalizedName("TFC Leather");
 
 		Straw = new ItemTerra(TFCItemID.Straw).setFolder("plants/").setUnlocalizedName("Straw");
 		FlatClay = (new ItemFlatGeneric(TFCItemID.FlatClay).setFolder("pottery/").setMetaNames(new String[]{"clay flat light", "clay flat dark", "clay flat fire", "clay flat dark fire"}).setUnlocalizedName(""));
@@ -1468,7 +1468,7 @@ public class TFCItems
 		PotteryLargeVessel = new ItemPotteryLargeVessel(TFCItemID.PotteryLargeVessel).setUnlocalizedName("Large Vessel");
 		PotteryPot = new ItemPotteryPot(TFCItemID.PotteryPot).setUnlocalizedName("Pot");
 		CeramicMold = new ItemPotteryBase(TFCItemID.CeramicMold).setMetaNames(new String[]{"Clay Mold","Ceramic Mold"}).setUnlocalizedName("Mold");
-		Item.itemsList[Item.clay.itemID] = null; Item.itemsList[Item.clay.itemID] = (new ItemClay(Item.clay.itemID).setSpecialCraftingType(FlatClay, new ItemStack(FlatClay, 1, 1))).setMetaNames(new String[]{"Clay", "Fire Clay"}).setUnlocalizedName("clay").setCreativeTab(CreativeTabs.tabMaterials);
+		Item.itemsList[Item.clay.itemID] = null; Item.itemsList[Item.clay.itemID] = (new ItemClay(Item.clay.itemID).setSpecialCraftingType(FlatClay, new ItemStack(FlatClay, 1, 1))).setMetaNames(new String[]{"Clay", "Fire Clay"}).setUnlocalizedName("clay");
 		ClayMoldAxe = new ItemPotteryMold(TFCItemID.ClayMoldAxe).setMetaNames(new String[]{"Clay Mold Axe","Ceramic Mold Axe",
 				"Ceramic Mold Axe Copper","Ceramic Mold Axe Bronze","Ceramic Mold Axe Bismuth Bronze","Ceramic Mold Axe Black Bronze"}).setUnlocalizedName("Axe Mold");
 		ClayMoldChisel = new ItemPotteryMold(TFCItemID.ClayMoldChisel).setMetaNames(new String[]{"Clay Mold Chisel","Ceramic Mold Chisel",


### PR DESCRIPTION
-Clay and Fire Clay to TFC Pottery
- Loose Rock, Sheet and Double Sheet to TFC Materials
- Removed two "setCreativeTab" overwriting

Not tested
Please let me know before next hotfix, I'll update the localization files for new cheese related items.
