### PR TITLE
Fixes #80, fixes #355, fixes #258

### DIFF
--- a/TFC_Shared/src/TFC/Blocks/Vanilla/BlockCustomLeaves.java
+++ b/TFC_Shared/src/TFC/Blocks/Vanilla/BlockCustomLeaves.java
@@ -188,17 +188,7 @@ public class BlockCustomLeaves extends BlockLeaves implements IShearable
 
     private void destroyLeaves(World world, int par1, int par2, int par3)
     {
-        world.setBlock(par1, par2, par3, 0, 0, 0x2);
-        world.scheduleBlockUpdate(par1 - 1, par2, par3, blockID, 5);
-        world.scheduleBlockUpdate(par1 + 1, par2, par3, blockID, 5);
-        world.scheduleBlockUpdate(par1, par2 - 1, par3, blockID, 5);
-        world.scheduleBlockUpdate(par1, par2 + 1, par3, blockID, 5);
-        world.scheduleBlockUpdate(par1, par2, par3 - 1, blockID, 5);
-        world.scheduleBlockUpdate(par1, par2, par3 + 1, blockID, 5);
-        world.scheduleBlockUpdate(par1 - 1, par2, par3+1, blockID, 5);
-        world.scheduleBlockUpdate(par1 - 1, par2, par3-1, blockID, 5);
-        world.scheduleBlockUpdate(par1 + 1, par2, par3+1, blockID, 5);
-        world.scheduleBlockUpdate(par1 + 1, par2, par3-1, blockID, 5);
+        world.setBlockToAir(par1, par2, par3);
     }
 
     private void removeLeaves(World world, int i, int j, int k)
@@ -206,7 +196,7 @@ public class BlockCustomLeaves extends BlockLeaves implements IShearable
         dropBlockAsItem(world, i, j, k, world.getBlockMetadata(i, j, k), 0);
         if(new Random().nextInt(100) < 30)
             dropBlockAsItem_do(world, i, j, k, new ItemStack(Item.stick, 1));
-        world.setBlock(i, j, k, 0);
+        world.setBlockToAir(i, j, k);
     }
 
     @Override

--- a/TFC_Shared/src/TFC/Core/Recipes.java
+++ b/TFC_Shared/src/TFC/Core/Recipes.java
@@ -601,6 +601,18 @@ public class Recipes
 			RemoveRecipe(new ItemStack(Item.dyePowder,3, 15));
 			RemoveRecipe(new ItemStack(Item.dyePowder,2, 1));
 			RemoveRecipe(new ItemStack(Item.dyePowder,2, 11));
+			
+			//Remove the vanilla stairs
+			RemoveRecipe(new ItemStack(Block.stairsWoodBirch, 4));
+			RemoveRecipe(new ItemStack(Block.stairsWoodJungle, 4));
+			RemoveRecipe(new ItemStack(Block.stairsWoodOak, 4));
+			RemoveRecipe(new ItemStack(Block.stairsWoodSpruce, 4));
+			
+			//Remove the vanilla slabs
+			RemoveRecipe(new ItemStack(Block.woodSingleSlab, 6, 0));
+			RemoveRecipe(new ItemStack(Block.woodSingleSlab, 6, 1));
+			RemoveRecipe(new ItemStack(Block.woodSingleSlab, 6, 2));
+			RemoveRecipe(new ItemStack(Block.woodSingleSlab, 6, 3));
 		}
 	}
 


### PR DESCRIPTION
#80 is fixed by removing the vanilla recipes for stairs and slabs
#355 is fixed by using setBlockToAir instead of setBlock to 0
#258 is fixed by instead of using the zombie attackEntityFrom(DamageSource par1DamageSource, float par2) which would spawn vanilla zombies to use the EntityLivingBase attackEntityFrom(DamageSource par1DamageSource, float par2)

Sorry for the twice "logomaster256 referenced this issue from a commit in logomaster256/TFCraft" I noticed that I didn't remove slabs so I did that and squashed and ^ happened
