### PR TITLE
Fixed Breaking a BarryBush that is higher..

### DIFF
--- a/TFC_Shared/src/TFC/Blocks/Flora/BlockBerryBush.java
+++ b/TFC_Shared/src/TFC/Blocks/Flora/BlockBerryBush.java
@@ -226,6 +226,7 @@ public class BlockBerryBush extends BlockTerraContainer
 		{
 			if(!canBlockStay(world, i, j, k))
 			{
+				this.dropBlockAsItem(world, i, j, k, world.getBlockMetadata(i, j, k), 0);
 				world.setBlockToAir(i, j, k);
 				return;
 			}


### PR DESCRIPTION
..then one block drops only one item. Also, placing a BarryBush where it
can't stay gets destroyed without dropping an item.
