### PR TITLE
English localisation update

### DIFF
--- a/TFC Resources/assets/terrafirmacraft/lang/en_US.properties
+++ b/TFC Resources/assets/terrafirmacraft/lang/en_US.properties
@@ -32,7 +32,7 @@ item.meal.fantastic=Fantastic
 #== Grains ==
 item.bread=Bread
 item.BarleyBread=Barley Bread
-item.CornBread=Corn Bread
+item.CornBread=Cornbread
 item.OatBread=Oat Bread
 item.RiceBread=Rice Bread
 item.RyeBread=Rye Bread
@@ -164,7 +164,7 @@ item.YellowBellPepper=Yellow Bell Pepper
 item.Cabbage=Cabbage
 item.Carrot=Carrot
 item.Garlic=Garlic
-item.Greenbeans=Greenbeans
+item.Greenbeans=Green Beans
 item.Onion=Onion
 item.Potato=Potato
 item.Rutabaga=Rutabaga
@@ -176,7 +176,7 @@ item.SeedsYellowBellPepper=Yellow Bell Pepper Seeds
 item.SeedsCabbage=Cabbage Seeds
 item.SeedsCarrot=Carrot Seeds
 item.SeedsGarlic=Garlic Seeds
-item.SeedsGreenbean=Greenbean Seeds
+item.SeedsGreenbean=Green Bean Seeds
 item.SeedsOnion=Onion Seeds
 item.SeedsPotato=Potato Seeds
 item.SeedsRutabaga=Rutabaga Seeds
@@ -210,8 +210,8 @@ item.Jug.WaterJug=Water Jug
 item.Pot.ClayPot=Clay Pot
 item.Pot.CeramicPot=Ceramic Pot
 
-item.SmallVessel.CeramicVessel=Ceramic Vessel
 item.SmallVessel.ClayVessel=Clay Vessel
+item.SmallVessel.CeramicVessel=Ceramic Vessel
 
 item.LargeVessel.ClayVessel[Large]=Clay Vessel [Large]
 item.LargeVessel.CeramicVessel[Large]=Ceramic Vessel [Large]
@@ -312,9 +312,9 @@ item.SwordMold.CeramicMoldSwordBismuthBronze=Sword Mold (Bismuth Bronze)
 
 item.Spindle=Spindle
 item.ClaySpindle=Clay Spindle
-item.Spindle.SpindleHead=Spindle Head
-item.SpindleHead=Spindle Head
 item.Spindle.ClaySpindle=Clay Spindle
+item.SpindleHead=Spindle Head
+item.Spindle.SpindleHead=Spindle Head
 
 item.FireBrick.FireBrick=Fire Brick
 item.FireBrick.ClayFireBrick=Clay Fire Brick
@@ -352,15 +352,15 @@ item.Tourmaline.Flawed=Flawed Tourmaline
 item.Agate.Normal=Agate 
 item.Amethyst.Normal=Amethyst 
 item.Beryl.Normal=Beryl 
-item.Diamond.Normal=Diamond 
+item.Diamond.Normal=Diamond
 item.Emerald.Normal=Emerald 
 item.Garnet.Normal=Garnet 
 item.Jade.Normal=Jade 
 item.Jasper.Normal=Jasper 
 item.Opal.Normal=Opal 
-item.Topaz.Normal=Topaz 
 item.Ruby.Normal=Ruby 
 item.Sapphire.Normal=Sapphire 
+item.Topaz.Normal=Topaz 
 item.Tourmaline.Normal=Tourmaline 
 
 item.Agate.Flawless=Flawless Agate
@@ -801,23 +801,23 @@ tile.Ore.Tetrahedrite=Tetrahedrite
 #= Wood =
 #========
 #== Wood Items ==
-item.Log.Acacia=Acacia
-item.Log.Ash=Ash
-item.Log.Aspen=Aspen
-item.Log.Birch=Birch
-item.Log.Chestnut=Chestnut
-item.Log.DouglasFir=Douglas Fir
-item.Log.Hickory=Hickory
-item.Log.Kapok=Kapok
-item.Log.Maple=Maple
-item.Log.Oak=Oak
-item.Log.Pine=Pine
-item.Log.Sequoia=Sequoia
-item.Log.Spruce=Spruce
-item.Log.Sycamore=Sycamore
-item.Log.WhiteCedar=White Cedar
-item.Log.WhiteElm=White Elm
-item.Log.Willow=Willow
+item.Log.Acacia=Acacia Log
+item.Log.Ash=Ash Log
+item.Log.Aspen=Aspen Log
+item.Log.Birch=Birch Log
+item.Log.Chestnut=Chestnut Log
+item.Log.DouglasFir=Douglas Fir Log
+item.Log.Hickory=Hickory Log
+item.Log.Kapok=Kapok Log
+item.Log.Maple=Maple Log
+item.Log.Oak=Oak Log
+item.Log.Pine=Pine Log
+item.Log.Sequoia=Sequoia Log
+item.Log.Spruce=Spruce Log
+item.Log.Sycamore=Sycamore Log
+item.Log.WhiteCedar=White Cedar Log
+item.Log.WhiteElm=White Elm Log
+item.Log.Willow=Willow Log
 
 item.SinglePlank.Acacia=Acacia Plank
 item.SinglePlank.Ash=Ash Plank
@@ -947,23 +947,23 @@ tile.wood.WhiteCedar=White Cedar Planks
 tile.wood.WhiteElm=White Elm Planks
 tile.wood.Willow=Willow Planks
 
-tile.AcaciaDoor=Acacia Door
-tile.AshDoor=Ash Door
-tile.AspenDoor=Aspen Door
-tile.BirchDoor=Birch Door
-tile.ChestnutDoor=Chestnut Door
-tile.DouglasFirDoor=Douglas Fir Door
-tile.HickoryDoor=Hickory Door
-tile.KapokDoor=Kapok Door
-tile.MapleDoor=Maple Door
-tile.OakDoor=Oak Door
-tile.PineDoor=Pine Door
-tile.SequoiaDoor=Sequoia Door
-tile.SpruceDoor=Spruce Door
-tile.SycamoreDoor=Sycamore Door
-tile.WhiteCedarDoor=White Cedar Door
-tile.WhiteElmDoor=White Elm Door
-tile.WillowDoor=Willow Door
+tile.Door Acacia=Acacia Door
+tile.Door Ash=Ash Door
+tile.Door Aspen=Aspen Door
+tile.Door Birch=Birch Door
+tile.Door Chestnut=Chestnut Door
+tile.Door DouglasFir=Douglas Fir Door
+tile.Door Hickory=Hickory Door
+tile.Door Kapok=Kapok Door
+tile.Door Maple=Maple Door
+tile.Door Oak=Oak Door
+tile.Door Pine=Pine Door
+tile.Door Sequoia=Sequoia Door
+tile.Door Spruce=Spruce Door
+tile.Door Sycamore=Sycamore Door
+tile.Door WhiteCedar=White Cedar Door
+tile.Door WhiteElm=White Elm Door
+tile.Door Willow=Willow Door
 
 tile.Barrel.Acacia=Acacia Barrel
 tile.Barrel.Ash=Ash Barrel
@@ -1770,7 +1770,7 @@ item.GoldPan.Gravel=Gold Pan - Gravel
 item.GoldPan.Clay=Gold Pan - Clay
 item.GoldPan.Dirt=Gold Pan - Dirt
 item.Ink=Marking
-item.Firestarter=Firestarter
+item.Firestarter=Fire Starter
 
 item.Quern=Handstone
 item.Blueprint=Blueprint
@@ -1925,8 +1925,8 @@ gui.Barrel.Sake=Sake
 gui.Barrel.Vodka=Vodka
 gui.Barrel.Whiskey=Whiskey
 gui.Barrel.Milk=Milk
-gui.Barrel.SaltWater=Salt Water
 gui.Barrel.CurdledMilk=Curdled Milk
+gui.Barrel.SaltWater=Salt Water
 gui.Barrel.Vinegar=Vinegar
 gui.Barrel.Water=Water
 gui.Barrel.Limewater=Limewater
@@ -2123,7 +2123,7 @@ gui.GoldPan.UseEmpty=Must use on sand in or near a river. Or gravel from under a
 gui.GoldPan.UseFull=Must use under flowing water.
 
 gui.ProPick.Found=Found
-gui.ProPick.FoundTraces=Found Traces of
+gui.ProPick.FoundTraces=Found traces of
 gui.ProPick.FoundSmall=Found a small sample of
 gui.ProPick.FoundMedium=Found a medium sample of
 gui.ProPick.FoundLarge=Found a large sample of
@@ -2149,5 +2149,5 @@ skill.agriculture=Agriculture
 skill.cooking=Cooking
 
 #=====================================================
-#======== Add New Stuff Here To Be Sorted Later========
+#========Add New Stuff Here To Be Sorted Later========
 #=====================================================


### PR DESCRIPTION
The changes are the following.
More consistent alphabetical order
*green bean seed moved to the same place as the beans
- all metal and rock occurrence sorted by alphabetical order (to avoid multiple order in the doc, so we have less chances of mistakes by translator)
- minerals moved before the metal ore so all the ore items are together (normal, rich, poor, small).
- unsorted the hit rules so we have 1, 2, 3, instead of 1, 10, 11 ... 2, 20
- revert to the propick result to the previous order, (traces, small, medium...)
