### PR TITLE
Large Hide fix

### DIFF
--- a/TFC_Shared/src/TFC/Entities/Mobs/EntityBear.java
+++ b/TFC_Shared/src/TFC/Entities/Mobs/EntityBear.java
@@ -295,7 +295,7 @@ public class EntityBear extends EntityTameable implements ICausesDamage, IAnimal
 	{
 		float ageMod = TFC_Core.getPercentGrown(this);
 
-		this.entityDropItem(new ItemStack(TFCItems.Hide.itemID,1,(int)(ageMod*3)),0);
+		this.entityDropItem(new ItemStack(TFCItems.Hide.itemID,1,Math.max(0,Math.min(2,(int)(ageMod*3-1)))),0);
 		this.dropItem(Item.bone.itemID,(int) ((rand.nextInt(6)+2)*ageMod));
 	}
 

--- a/TFC_Shared/src/TFC/Entities/Mobs/EntityCowTFC.java
+++ b/TFC_Shared/src/TFC/Entities/Mobs/EntityCowTFC.java
@@ -286,7 +286,7 @@ public class EntityCowTFC extends EntityCow implements IAnimal
 		float ageMod = TFC_Core.getPercentGrown(this);
 
 
-		this.entityDropItem(new ItemStack(TFCItems.Hide.itemID,1,(int)(ageMod*3)),0);
+		this.entityDropItem(new ItemStack(TFCItems.Hide.itemID,1,Math.max(0,Math.min(2,(int)(ageMod*3-1)))),0);
 		this.dropItem(Item.bone.itemID,(int) ((rand.nextInt(6)+3)*ageMod));
 
 		float foodWeight = ageMod*(this.size_mod * 4000);//528 oz (33lbs) is the average yield of lamb after slaughter and processing

--- a/TFC_Shared/src/TFC/Entities/Mobs/EntityDeer.java
+++ b/TFC_Shared/src/TFC/Entities/Mobs/EntityDeer.java
@@ -261,7 +261,7 @@ public class EntityDeer extends EntityAnimal implements IAnimal
 	protected void dropFewItems(boolean par1, int par2)
 	{
 		float ageMod = TFC_Core.getPercentGrown(this);	
-		this.entityDropItem(new ItemStack(TFCItems.Hide.itemID,1,(int)(ageMod*size_mod*1.84)),0);
+		this.entityDropItem(new ItemStack(TFCItems.Hide.itemID,1,Math.max(0,Math.min(2,(int)(ageMod*size_mod*1.84)))),0);
 		this.dropItem(Item.bone.itemID, (int)((rand.nextInt(4)+2)*ageMod));
 		float foodWeight = ageMod*(this.size_mod * 2400);//528 oz (33lbs) is the average yield of lamb after slaughter and processing
 

--- a/TFC_Shared/src/TFC/Entities/Mobs/EntityHorseTFC.java
+++ b/TFC_Shared/src/TFC/Entities/Mobs/EntityHorseTFC.java
@@ -1155,7 +1155,7 @@ public class EntityHorseTFC extends EntityHorse implements IInvBasic, IAnimal
 	{
 		float ageMod = TFC_Core.getPercentGrown(this);
 
-		this.entityDropItem(new ItemStack(TFCItems.Hide.itemID,1,(int)(ageMod*3)),0);
+		this.entityDropItem(new ItemStack(TFCItems.Hide.itemID,1,Math.max(0,Math.min(2,(int)(ageMod*3-1)))),0);
 		this.dropItem(Item.bone.itemID,(int) ((rand.nextInt(8)+3)*ageMod));
 
 		float foodWeight = ageMod*(this.size_mod * 4000);//528 oz (33lbs) is the average yield of lamb after slaughter and processing

--- a/TFC_Shared/src/TFC/Entities/Mobs/EntityPigTFC.java
+++ b/TFC_Shared/src/TFC/Entities/Mobs/EntityPigTFC.java
@@ -312,7 +312,7 @@ public class EntityPigTFC extends EntityPig implements IAnimal
 		int var4;
 		float ageMod = TFC_Core.getPercentGrown(this);
 
-		this.entityDropItem(new ItemStack(TFCItems.Hide.itemID,1,(int)(ageMod*size_mod)),0);
+		this.entityDropItem(new ItemStack(TFCItems.Hide.itemID,1,Math.max(0,Math.min(2,(int)(ageMod*size_mod)))),0);
 		this.dropItem(Item.bone.itemID, (int) ((rand.nextInt(4)+2)*ageMod));
 
 		float foodWeight = ageMod*(this.size_mod * 2400);//528 oz (33lbs) is the average yield of lamb after slaughter and processing

--- a/TFC_Shared/src/TFC/Entities/Mobs/EntitySheepTFC.java
+++ b/TFC_Shared/src/TFC/Entities/Mobs/EntitySheepTFC.java
@@ -263,9 +263,9 @@ public class EntitySheepTFC extends EntitySheep implements IShearable, IAnimal
 		float ageMod = TFC_Core.getPercentGrown(this);
 
 		if(!this.getSheared())
-			this.entityDropItem(new ItemStack(TFCItems.SheepSkin,1,(int)(ageMod * size_mod)), 0.0F);
+			this.entityDropItem(new ItemStack(TFCItems.SheepSkin,1,Math.max(0,Math.min(2,(int)(ageMod * size_mod)))), 0.0F);
 		else
-			this.entityDropItem(new ItemStack(TFCItems.Hide,1,(int)(ageMod * size_mod)), 0.0F);
+			this.entityDropItem(new ItemStack(TFCItems.Hide,1,Math.max(0,Math.min(2,(int)(ageMod * size_mod)))), 0.0F);
 		this.dropItem(Item.bone.itemID, (int)((rand.nextInt(5)+2)*ageMod));
 
 

--- a/TFC_Shared/src/TFC/Entities/Mobs/EntityWolfTFC.java
+++ b/TFC_Shared/src/TFC/Entities/Mobs/EntityWolfTFC.java
@@ -336,7 +336,7 @@ public class EntityWolfTFC extends EntityWolf implements IAnimal, IInnateArmor
 	{
 		float ageMod = TFC_Core.getPercentGrown(this);
 
-		this.entityDropItem(new ItemStack(TFCItems.Hide.itemID,1,(int)(size_mod*ageMod*0.9)),0);
+		this.entityDropItem(new ItemStack(TFCItems.Hide.itemID,1,Math.max(0,Math.min(2,(int)(size_mod*ageMod*0.9)))),0);
 		this.dropItem(Item.bone.itemID, (int)((rand.nextInt(3)+1)*ageMod));
 	}
 

--- a/TFC_Shared/src/TFC/Items/ItemRawHide.java
+++ b/TFC_Shared/src/TFC/Items/ItemRawHide.java
@@ -41,7 +41,7 @@ public class ItemRawHide extends ItemLooseRock
 	@Override
 	public boolean onItemUse(ItemStack itemstack, EntityPlayer entityplayer, World world, int x, int y, int z, int side, float hitX, float hitY, float hitZ)
 	{
-		if(!world.isRemote && itemstack.getItem() == TFCItems.Hide && itemstack.getItemDamage() == 2){
+		if(!world.isRemote && itemstack.getItem() == TFCItems.Hide && itemstack.getItemDamage() >= 2){
 			int d = (int)((45 + ((entityplayer.rotationYaw % 360)+360f)%360)/90)%4; //direction
 			int x2 = x+(d==1?-1:(d==3?1:0)); // the x-coord of the second block
 			int z2 = z+(d==2?-1:(d==0?1:0));


### PR DESCRIPTION
Adult cows, bears, and horses will always drop an unusable item 16996:3 (should be 16996:2). Added clamping to prevent that in the future even with any super-sized animals and adjusted the formulas for cows, bears, horses. Also previously unusable raw hides can be used for beds.
