### PR TITLE
Fix splitting 100% refined bloom

### DIFF
--- a/TFC API/TFC/API/Crafting/AnvilManager.java
+++ b/TFC API/TFC/API/Crafting/AnvilManager.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import TFC.TFCItems;
 import net.minecraft.item.ItemStack;
 
 public class AnvilManager
@@ -59,7 +60,15 @@ public class AnvilManager
 		{
 			AnvilRecipe irecipe = (AnvilRecipe)recipes.get(k);
 			if (irecipe.matches(recipe))
+			{
+				if (recipe.input1 != null && recipe.input1.getItem() == TFCItems.Bloom && irecipe.plan == "splitbloom") //.getCraftingResult().getItem() == TFCItems.Bloom)
+				{
+					if (recipe.input1.getItemDamage() <= 100)
+						return null;
+				}
+
 				return irecipe;
+			}
 		}
 
 		return null;

--- a/TFC_Shared/src/TFC/GUI/GuiPlanSelection.java
+++ b/TFC_Shared/src/TFC/GUI/GuiPlanSelection.java
@@ -103,23 +103,11 @@ public class GuiPlanSelection extends GuiContainerTFC
 			AnvilRecipe ar = manager.findMatchingRecipe(new AnvilRecipe(AnvilEntity.anvilItemStacks[AnvilEntity.INPUT1_SLOT], AnvilEntity.anvilItemStacks[AnvilEntity.INPUT2_SLOT], 
 					(String)p,AnvilReq.getReqFromInt(AnvilEntity.AnvilTier), null));
 
-			ar = handleMatchingRecipe(ar);
 			if(ar != null) 
 				planList.add(new Object[]{(String)p, ar});
 		}
 		return planList;
 
-	}
-
-	AnvilRecipe handleMatchingRecipe(AnvilRecipe ar)
-	{
-		if (ar != null)
-		if (AnvilEntity.anvilItemStacks[AnvilEntity.INPUT1_SLOT] != null && AnvilEntity.anvilItemStacks[AnvilEntity.INPUT1_SLOT].getItem() == TFCItems.RawBloom && ar.getCraftingResult().getItem() == TFCItems.RawBloom)
-		{
-			if (AnvilEntity.anvilItemStacks[AnvilEntity.INPUT1_SLOT].getItemDamage() <= 100)
-				return null;
-		}
-		return ar;
 	}
 
 	public void drawTooltip(int mx, int my, String text) {


### PR DESCRIPTION
Move some recipe validation to the anvil crafting manager so it can be used in multiple places (plan selection GUI as well as TileEntityAnvil), and nullify the recipe if it would split a 100% Refined Bloom, even if the plan was selected before the bloom was placed in the input. Fixes http://terrafirmacraft.com/f/topic/5488-789-can-split-100-refined-bloom/
