### PR TITLE
Fix taming wolves setting their current HP to 20

### DIFF
--- a/TFC_Shared/src/TFC/Entities/Mobs/EntityWolfTFC.java
+++ b/TFC_Shared/src/TFC/Entities/Mobs/EntityWolfTFC.java
@@ -496,11 +496,10 @@ public class EntityWolfTFC extends EntityWolf implements IAnimal, IInnateArmor
 			//par1EntityPlayer.addChatMessage("12: "+dataWatcher.getWatchableObjectInt(12)+", 15: "+dataWatcher.getWatchableObjectInt(15));
 		}
 		
-		boolean wasTamed = false;
+		boolean wasTamedBefore = this.isTamed();
 		boolean interactSuper = super.interact(par1EntityPlayer);
-		wasTamed = this.isTamed();
 		
-		if (!worldObj.isRemote && wasTamed)
+		if (!worldObj.isRemote && wasTamedBefore == false && this.isTamed())
 		{
 			this.setHealth(TFC_MobData.WolfHealth);
 		}


### PR DESCRIPTION
Reset wolf health to TFC values after the vanilla taming code sets it to 20. Fixes http://terrafirmacraft.com/f/topic/5500-b789-tamed-wolf-issue/
