### PR TITLE
Centralized TileEntity Names so saves are compatible between SSP-SMP

### DIFF
--- a/src/Common/com/bioxx/tfc/ClientProxy.java
+++ b/src/Common/com/bioxx/tfc/ClientProxy.java
@@ -255,18 +255,18 @@ public class ClientProxy extends CommonProxy
 	public void registerTileEntities(boolean b)
 	{
 		super.registerTileEntities(false);
-		ClientRegistry.registerTileEntity(TileEntityChestTFC.class, "chest", new TESRChest());
-		ClientRegistry.registerTileEntity(TileEntityIngotPile.class, "ingotPile2", new TESRIngotPile());
-		ClientRegistry.registerTileEntity(TileEntityFirepit.class, "firepit", new TESRFirepit());
-		ClientRegistry.registerTileEntity(TESeaWeed.class, "seaweed", new TESRSeaWeed());
+		ClientRegistry.registerTileEntity(TileEntityChestTFC.class, TileEntityName.Chest, new TESRChest());
+		ClientRegistry.registerTileEntity(TileEntityIngotPile.class, TileEntityName.IngotPile, new TESRIngotPile());
+		ClientRegistry.registerTileEntity(TileEntityFirepit.class, TileEntityName.Firepit, new TESRFirepit());
+		ClientRegistry.registerTileEntity(TESeaWeed.class, TileEntityName.SeaWeed, new TESRSeaWeed());
 		//ModLoader.registerTileEntity(TileEntityBarrel.class, "barrel", new TileEntityBarrelRendererTFC());
-		ClientRegistry.registerTileEntity(TileEntityPottery.class, "Pottery", new TESRPottery());
-		ClientRegistry.registerTileEntity(TEFoodPrep.class, "FoodPrep", new TESRFoodPrep());
-		ClientRegistry.registerTileEntity(TileEntityBellows.class, "Bellows", new TESRBellows());
-		ClientRegistry.registerTileEntity(TileEntityToolRack.class, "ToolRack", new TESRToolrack());
-		ClientRegistry.registerTileEntity(TileEntityAnvil.class, "Anvil", new TESRAnvil());
-		ClientRegistry.registerTileEntity(TEWorldItem.class, "worlditem", new TESRWorldItem());
-		ClientRegistry.registerTileEntity(TileEntityQuern.class, "quern", new TESRQuern());
+		ClientRegistry.registerTileEntity(TileEntityPottery.class, TileEntityName.Pottery, new TESRPottery());
+		ClientRegistry.registerTileEntity(TEFoodPrep.class, TileEntityName.FoodPrep, new TESRFoodPrep());
+		ClientRegistry.registerTileEntity(TileEntityBellows.class, TileEntityName.Bellows, new TESRBellows());
+		ClientRegistry.registerTileEntity(TileEntityToolRack.class, TileEntityName.ToolRack, new TESRToolrack());
+		ClientRegistry.registerTileEntity(TileEntityAnvil.class, TileEntityName.Anvil, new TESRAnvil());
+		ClientRegistry.registerTileEntity(TEWorldItem.class, TileEntityName.WorldItem, new TESRWorldItem());
+		ClientRegistry.registerTileEntity(TileEntityQuern.class, TileEntityName.Quern, new TESRQuern());
 	}
 
 	@Override

--- a/src/Common/com/bioxx/tfc/CommonProxy.java
+++ b/src/Common/com/bioxx/tfc/CommonProxy.java
@@ -110,45 +110,44 @@ public class CommonProxy
 
 	public void registerTileEntities(boolean b)
 	{
-		GameRegistry.registerTileEntity(TileEntityLogPile.class, "TerraLogPile");
-		GameRegistry.registerTileEntity(TileEntityWorkbench.class, "TerraWorkbench");
-		GameRegistry.registerTileEntity(TileEntityFirepit.class, "TerraFirepit");
-		GameRegistry.registerTileEntity(TEForge.class, "TerraForge");
-		GameRegistry.registerTileEntity(TEBlastFurnace.class, "TerraBloomery");
-		GameRegistry.registerTileEntity(TileEntityEarlyBloomery.class, "TerraEarlyBloomery");
-		GameRegistry.registerTileEntity(TileEntitySluice.class, "TerraSluice");
-		GameRegistry.registerTileEntity(TileEntityFarmland.class, "TileEntityFarmland");
-		GameRegistry.registerTileEntity(TECrop.class, "TileEntityCrop");
-		GameRegistry.registerTileEntity(TileEntityFruitTreeWood.class, "FruitTreeWood");
-		GameRegistry.registerTileEntity(TileEntityPartial.class, "Partial");
-		GameRegistry.registerTileEntity(TileEntityDetailed.class, "Detailed");
-		GameRegistry.registerTileEntity(TileEntitySpawnMeter.class, "SpawnMeter");
-		GameRegistry.registerTileEntity(TileEntityQuern.class, "Quern");
-		GameRegistry.registerTileEntity(TileEntitySapling.class, "Sapling");
-		GameRegistry.registerTileEntity(TileEntityWoodConstruct.class, "Wood Construct");
-		GameRegistry.registerTileEntity(TEBarrel.class, "Barrel");
-		GameRegistry.registerTileEntity(TileEntityFenceGate.class, "FenceGate");
-		GameRegistry.registerTileEntity(TileEntityBloom.class, "IronBloom");
-		GameRegistry.registerTileEntity(TECrucible.class, "Crucible");
-		GameRegistry.registerTileEntity(TENestBox.class, "Nest Box");
-		GameRegistry.registerTileEntity(TEStand.class, "Armour Stand");
-		GameRegistry.registerTileEntity(TEBerryBush.class, "Berry Bush");
-		GameRegistry.registerTileEntity(TESeaWeed.class, "Sea Weed");
-		GameRegistry.registerTileEntity(TEFruitLeaves.class, "Fruit Leaves");
-		GameRegistry.registerTileEntity(TEMetalSheet.class, "Metal Sheet");
-		GameRegistry.registerTileEntity(TEOre.class, "ore");
+		GameRegistry.registerTileEntity(TileEntityLogPile.class, TileEntityName.LogPile);
+		GameRegistry.registerTileEntity(TileEntityWorkbench.class, TileEntityName.Workbench);
+		GameRegistry.registerTileEntity(TEForge.class, TileEntityName.Forge);
+		GameRegistry.registerTileEntity(TEBlastFurnace.class, TileEntityName.BlastFurnace);
+		GameRegistry.registerTileEntity(TileEntityEarlyBloomery.class, TileEntityName.Bloomery);
+		GameRegistry.registerTileEntity(TileEntitySluice.class, TileEntityName.Sluice);
+		GameRegistry.registerTileEntity(TileEntityFarmland.class, TileEntityName.Farmland);
+		GameRegistry.registerTileEntity(TECrop.class, TileEntityName.Crop);
+		GameRegistry.registerTileEntity(TileEntityFruitTreeWood.class, TileEntityName.FruitTreeWood);
+		GameRegistry.registerTileEntity(TileEntityPartial.class, TileEntityName.Partial);
+		GameRegistry.registerTileEntity(TileEntityDetailed.class, TileEntityName.Detailed);
+		GameRegistry.registerTileEntity(TileEntitySpawnMeter.class, TileEntityName.SpawnMeter);
+		GameRegistry.registerTileEntity(TileEntitySapling.class, TileEntityName.Sapling);
+		GameRegistry.registerTileEntity(TileEntityWoodConstruct.class, TileEntityName.WoodConstruct);
+		GameRegistry.registerTileEntity(TEBarrel.class, TileEntityName.Barrel);
+		GameRegistry.registerTileEntity(TileEntityFenceGate.class, TileEntityName.FenceGate);
+		GameRegistry.registerTileEntity(TileEntityBloom.class, TileEntityName.Bloom);
+		GameRegistry.registerTileEntity(TECrucible.class, TileEntityName.Crucible);
+		GameRegistry.registerTileEntity(TENestBox.class, TileEntityName.NestBox);
+		GameRegistry.registerTileEntity(TEStand.class, TileEntityName.Stand);
+		GameRegistry.registerTileEntity(TEBerryBush.class, TileEntityName.BerryBush);
+		GameRegistry.registerTileEntity(TEFruitLeaves.class, TileEntityName.FruitLeaves);
+		GameRegistry.registerTileEntity(TEMetalSheet.class, TileEntityName.MetalSheet);
+		GameRegistry.registerTileEntity(TEOre.class, TileEntityName.Ore);
 
 		if(b)
 		{
-			GameRegistry.registerTileEntity(TileEntityIngotPile.class, "ingotPile");
-			GameRegistry.registerTileEntity(TileEntityPottery.class, "Pottery");
-			GameRegistry.registerTileEntity(TileEntityChestTFC.class, "chest");
-			GameRegistry.registerTileEntity(TEFoodPrep.class, "FoodPrep");
-			GameRegistry.registerTileEntity(TileEntityBellows.class, "Bellows");
-			GameRegistry.registerTileEntity(TileEntityToolRack.class, "ToolRack");
-			GameRegistry.registerTileEntity(TileEntityAnvil.class, "TerraAnvil");
-			GameRegistry.registerTileEntity(TEWorldItem.class, "worldItem");
-			GameRegistry.registerTileEntity(TileEntityQuern.class, "quern");
+			GameRegistry.registerTileEntity(TileEntityFirepit.class, TileEntityName.Firepit);
+			GameRegistry.registerTileEntity(TESeaWeed.class, TileEntityName.SeaWeed);
+			GameRegistry.registerTileEntity(TileEntityIngotPile.class, TileEntityName.IngotPile);
+			GameRegistry.registerTileEntity(TileEntityPottery.class, TileEntityName.Pottery);
+			GameRegistry.registerTileEntity(TileEntityChestTFC.class, TileEntityName.Chest);
+			GameRegistry.registerTileEntity(TEFoodPrep.class, TileEntityName.FoodPrep);
+			GameRegistry.registerTileEntity(TileEntityBellows.class, TileEntityName.Bellows);
+			GameRegistry.registerTileEntity(TileEntityToolRack.class, TileEntityName.ToolRack);
+			GameRegistry.registerTileEntity(TileEntityAnvil.class, TileEntityName.Anvil);
+			GameRegistry.registerTileEntity(TEWorldItem.class, TileEntityName.WorldItem);
+			GameRegistry.registerTileEntity(TileEntityQuern.class, TileEntityName.Quern);
 		}
 
 		EntityRegistry.registerGlobalEntityID(EntitySquidTFC.class, "squidTFC", EntityRegistry.findGlobalUniqueEntityId(), 0xffffff, 0xbbbbbb);

--- a/src/Common/com/bioxx/tfc/TileEntityName.java
+++ b/src/Common/com/bioxx/tfc/TileEntityName.java
@@ -1,0 +1,41 @@
+package com.bioxx.tfc;
+
+public class TileEntityName {
+	
+	public static final String LogPile = "TerraLogPile";
+	public static final String Workbench = "TerraWorkbench";
+	public static final String Firepit = "TerraFirepit";
+	public static final String Forge = "TerraForge";
+	public static final String BlastFurnace = "TerraBloomery";
+	public static final String Bloomery = "TerraEarlyBloomery";
+	public static final String Sluice = "TerraSluice";
+	public static final String Farmland = "TileEntityFarmland";
+	public static final String Crop = "TileEntityCrop";
+	public static final String FruitTreeWood = "FruitTreeWood";
+	public static final String Partial = "Partial";
+	public static final String Detailed = "Detailed";
+	public static final String SpawnMeter = "SpawnMeter";
+	public static final String Quern = "Quern";
+	public static final String Sapling = "Sapling";
+	public static final String WoodConstruct = "WoodConstruct";
+	public static final String Barrel = "Barrel";
+	public static final String FenceGate = "FenceGate";
+	public static final String Bloom = "IronBloom";
+	public static final String Crucible = "Crucible";
+	public static final String NestBox = "Nest Box";
+	public static final String Stand = "Armour Stand";
+	public static final String BerryBush = "Berry Bush";
+	public static final String SeaWeed = "Sea Weed";
+	public static final String FruitLeaves = "Fruit Leaves";
+	public static final String MetalSheet = "Metal Sheet";
+	public static final String Ore = "ore";
+	public static final String IngotPile = "ingotPile";
+	public static final String Pottery = "Pottery";
+	public static final String Chest = "chest";
+	public static final String FoodPrep = "FoodPrep";
+	public static final String Bellows = "Bellows";
+	public static final String ToolRack = "ToolRack";
+	public static final String Anvil = "TerraAnvil";
+	public static final String WorldItem = "worldItem";
+
+}


### PR DESCRIPTION
Added TileEntityName.java, I hope that is acceptable.

In build 78 you cannot move worlds from SSP to SMP (or vice versa) because tile entities are given different String ids on server side as opposed to client side.

This centralizes the name strings so it's easy to be sure they are kept consistent.
