### PR TITLE
Fix splitting 100% refined bloom. Plans now auto-select when possible.

### DIFF
--- a/TFC_Shared/src/TFC/GUI/GuiPlanSelection.java
+++ b/TFC_Shared/src/TFC/GUI/GuiPlanSelection.java
@@ -114,11 +114,11 @@ public class GuiPlanSelection extends GuiContainerTFC
 	AnvilRecipe handleMatchingRecipe(AnvilRecipe ar)
 	{
 		if (ar != null)
-		if (AnvilEntity.anvilItemStacks[AnvilEntity.INPUT1_SLOT] != null && AnvilEntity.anvilItemStacks[AnvilEntity.INPUT1_SLOT].getItem() == TFCItems.RawBloom && ar.getCraftingResult().getItem() == TFCItems.RawBloom)
-		{
-			if (AnvilEntity.anvilItemStacks[AnvilEntity.INPUT1_SLOT].getItemDamage() <= 100)
-				return null;
-		}
+			if (AnvilEntity.anvilItemStacks[AnvilEntity.INPUT1_SLOT] != null && AnvilEntity.anvilItemStacks[AnvilEntity.INPUT1_SLOT].getItem() == TFCItems.Bloom && ar.getCraftingResult().getItem() == TFCItems.Bloom)
+			{
+				if (AnvilEntity.anvilItemStacks[AnvilEntity.INPUT1_SLOT].getItemDamage() <= 100)
+					return null;
+			}
 		return ar;
 	}
 


### PR DESCRIPTION
Fix splitting 100% refined bloom.
Plans now auto-select based on input if there is only one possible plan.
