### PR TITLE
Fixed bow critical hits

### DIFF
--- a/TFC_Shared/src/TFC/Items/Tools/ItemCustomBow.java
+++ b/TFC_Shared/src/TFC/Items/Tools/ItemCustomBow.java
@@ -119,7 +119,7 @@ public class ItemCustomBow extends ItemBow implements ISize
 
 			EntityProjectileTFC entityarrow = new EntityProjectileTFC(world, player, forceMult * 2.0F, Item.arrow.itemID);
 			entityarrow.setDamage(forceMult * 150.0);
-			if (forceMult == 1.0F)
+			if (forceMult == 1.25F)
 			{
 				entityarrow.setIsCritical(true);
 			}


### PR DESCRIPTION
I looked through the history and bow critis being disabled seemed to be an accident, so I'm submitting this to enable them again.

It takes charging the bow for nearly 6 full seconds to get a bow crit in the current system, so I don't think it's likely to be overused.
