### PR TITLE
Fix Javelin entity pickup

### DIFF
--- a/src/Common/com/bioxx/tfc/Entities/EntityJavelin.java
+++ b/src/Common/com/bioxx/tfc/Entities/EntityJavelin.java
@@ -1,10 +1,10 @@
 package com.bioxx.tfc.Entities;
 
-import com.bioxx.tfc.api.ICausesDamage;
-import com.bioxx.tfc.api.Enums.EnumDamageType;
-
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.world.World;
+
+import com.bioxx.tfc.api.ICausesDamage;
+import com.bioxx.tfc.api.Enums.EnumDamageType;
 
 public class EntityJavelin extends EntityProjectileTFC implements ICausesDamage
 {

--- a/src/Common/com/bioxx/tfc/Entities/EntityProjectileTFC.java
+++ b/src/Common/com/bioxx/tfc/Entities/EntityProjectileTFC.java
@@ -4,6 +4,7 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.projectile.EntityArrow;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
@@ -17,6 +18,7 @@ import com.bioxx.tfc.api.Enums.EnumDamageType;
 public class EntityProjectileTFC extends EntityArrow implements ICausesDamage
 {
 	public short damageTaken = 0;
+	public Item pickupItem = TFCItems.Arrow;
 
 	public EntityProjectileTFC(World par1World)
 	{
@@ -43,6 +45,11 @@ public class EntityProjectileTFC extends EntityArrow implements ICausesDamage
 		damageTaken = d;
 	}
 
+	public void setPickupItem(Item item)
+	{
+		pickupItem = item;
+	}
+
 	@Override
 	public void onCollideWithPlayer(EntityPlayer player)
 	{
@@ -56,7 +63,7 @@ public class EntityProjectileTFC extends EntityArrow implements ICausesDamage
 			{
 				boolean flag = this.canBePickedUp == 1 || this.canBePickedUp == 2 && player.capabilities.isCreativeMode;
 
-				EntityItem ei = new EntityItem(this.worldObj, this.posX, this.posY, this.posZ, new ItemStack(TFCItems.Arrow, 1, this.damageTaken));
+				EntityItem ei = new EntityItem(this.worldObj, this.posX, this.posY, this.posZ, new ItemStack(this.pickupItem, 1, this.damageTaken));
 				EntityItemPickupEvent event = new EntityItemPickupEvent(player, ei);
 
 				if (MinecraftForge.EVENT_BUS.post(event))

--- a/src/Common/com/bioxx/tfc/Items/Tools/ItemJavelin.java
+++ b/src/Common/com/bioxx/tfc/Items/Tools/ItemJavelin.java
@@ -132,6 +132,7 @@ public class ItemJavelin extends ItemTerraTool implements ICausesDamage, IProjec
 
 		world.playSoundAtEntity(player, "random.bow", 1.0F, 0.3F);
 		javelin.setDamageTaken((short) itemstack.getItemDamage());
+		javelin.setPickupItem(itemstack.getItem());
 
 		player.inventory.mainInventory[player.inventory.currentItem] = null;
 


### PR DESCRIPTION
All thrown Javelins were being picked up as arrows.

Adds a new field to EntityProjectileTFC, not hard-coded so it's still expandable if you ever add more projectiles.
