### PR TITLE
Updated config file message to match the new pit kiln

### DIFF
--- a/TFC_Shared/src/TFC/TerraFirmaCraft.java
+++ b/TFC_Shared/src/TFC/TerraFirmaCraft.java
@@ -362,7 +362,7 @@ public class TerraFirmaCraft
 
 		TFCOptions.enableCropsDie = TFCOptions.getBooleanFor(config, "Crops","enableCropsDie",false);
 
-		TFCOptions.pitKilnBurnTime = TFCOptions.getIntFor(config,"General","pitKilnBurnTime", 8, "This is the number of hours that the pit kiln should burn before being completed. Longer than 8 hours will require players to feed extra logs to the fire beyond the initial 16 in the full log pile. Logs burn for 30 minutes each.");
+		TFCOptions.pitKilnBurnTime = TFCOptions.getIntFor(config,"General","pitKilnBurnTime", 8, "This is the number of hours that the pit kiln should burn before being completed.");
 		TFCOptions.maxProtectionMonths = TFCOptions.getIntFor(config,"Protection","maxProtectionMonths", 10, "The maximum number of months of spawn protection that can accumulate.");
 		TFCOptions.protectionGain = TFCOptions.getIntFor(config,"Protection","protectionGain", 8, "The number of hours of protection gained in the 3x3 chunk area for spending 1 hour in that chunk.");
 


### PR DESCRIPTION
The single block does not support varied number of logs, it's always 8, so this eliminates inaccurate info.

Mostly intended to help avoid misinformation on the wiki, since the config message is shown on the pit kiln/pottery page.
