### PR TITLE
Fix ingot pile dupe bug

### DIFF
--- a/TFC_Shared/src/TFC/Blocks/BlockIngotPile.java
+++ b/TFC_Shared/src/TFC/Blocks/BlockIngotPile.java
@@ -94,7 +94,7 @@ public class BlockIngotPile extends BlockTerraContainer
 		
 		int bottomSize = teipBottom.getStackInSlot(0).stackSize;
 		int topSize = teip.getStackInSlot(0).stackSize;
-		
+
 		if(bottomSize < 64)
 		{
 			bottomSize = bottomSize + topSize;
@@ -116,7 +116,10 @@ public class BlockIngotPile extends BlockTerraContainer
 				teip.broadcastPacketInRange(teip.createUpdatePacket());
 			}
 			else
+			{
+				teip.storage[0] = null;
 				world.setBlockToAir(i, j, k);
+			}
 		}
 	}
 


### PR DESCRIPTION
setBlockToAir calls breakBlock (in a roundabout way) which causes all BlockTerraContainers to drop their contents. Since the storage was not cleared first, this dropped an extra ingot.
