### PR TITLE
.gitignore for OSX/Linux terminal development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,18 @@
+.DS_Store
 *.pyc
+*~
+*swp
 TFC Build/
 bin/
 .gradle/
 build/
 .settings/
+logs/
+assets/
+crash-reports/
+config/
+saves/
+screenshots/
 .project
 .classpath
+options.txt


### PR DESCRIPTION
Added a few vim/eclipse/OSX detritus files, as well as MC folders, which the default eclipse Launch Profile creates.
