### PR TITLE
Fixing Bellows extending fuel life

### DIFF
--- a/src/Common/com/bioxx/tfc/TileEntities/TEFireEntity.java
+++ b/src/Common/com/bioxx/tfc/TileEntities/TEFireEntity.java
@@ -63,7 +63,7 @@ public class TEFireEntity extends NetworkTileEntity
 		if(fuelTimeLeft > 0)
 		{
 			fuelTimeLeft--;
-			if(airFromBellows == 0)
+			if(airFromBellows > 0)
 				fuelTimeLeft--;
 		}
 		else if(fuelTimeLeft < 0)


### PR DESCRIPTION
In discussions on IRC, this seems like the intended behavior. Otherwise, the bellows was extending fuel life instead of reducing it.
