### PR TITLE
Fix AnvilRecipe returning mutable result.

### DIFF
--- a/src/API/com/bioxx/tfc/api/Crafting/AnvilRecipe.java
+++ b/src/API/com/bioxx/tfc/api/Crafting/AnvilRecipe.java
@@ -185,7 +185,7 @@ public class AnvilRecipe
 	 */
 	public ItemStack getCraftingResult(ItemStack input)
 	{
-		ItemStack is = result;
+		ItemStack is = result.copy();
 		if(this.inheritsDamage)
 			is.setItemDamage(input.getItemDamage());
 		return is;


### PR DESCRIPTION
Before this fix, with the output of a weld in WELDOUT_SLOT and
the same item type in INPUT1_SLOT, picking up the item in WELDOUT
and moving to INPUT1 swapped the two ItemStacks. Applying any anvil
work to the now INPUT1 item stack was actually modifying the
AnvilRecipe.result.
