### PR TITLE
[0.79] Possible fix for players immediately starving after logging back in

### DIFF
--- a/src/Common/com/bioxx/tfc/Core/Player/FoodStatsTFC.java
+++ b/src/Common/com/bioxx/tfc/Core/Player/FoodStatsTFC.java
@@ -79,7 +79,7 @@ public class FoodStatsTFC
 			/*
 			 * Standard filling reduction based upon time.
 			 */
-			if(this.foodTimer < TFC_Time.startTime)
+			if(this.foodTimer <= TFC_Time.startTime)
 			{
 				resetTimers();
 			}


### PR DESCRIPTION
As I mentioned in issue 553, players will take starvation damage if they logout and then log back in after some time.  This is my best guess for a fix to that problem (I'm not 100% sure if there are side effects).

According to eclipse when the player first logs in, their foodTimer is set to 0 (probably a bug - I think it's 0 in the NBT data too), which immediately triggers the condition in FoodStats.java line 82 and sets their foodTimer to the beginning of time (576000).  They then proceed to take starvation damage for every hour the world has been previously active.  All I did to "fix" it was reset their foodTimer to the current time (using the handy reset function) instead of 576000.

When I tested this I logged into a world several (in-game) hours old with the old code and immediately lost all my hunger, then I reverted the world (so the world timer was the same) and patched the code, logged in and didn't lose my hunger.

It seems to address the issue, but I am unable to determine if there are side effects anywhere.  I also noted that version 78.17 had this same behaviour (reset timer to 576000) but I never experienced this problem with that version.
