### PR TITLE
[0.79] Fixed a bug preventing pit kiln from staying lit

### DIFF
--- a/src/Common/com/bioxx/tfc/TileEntities/TEPottery.java
+++ b/src/Common/com/bioxx/tfc/TileEntities/TEPottery.java
@@ -198,10 +198,10 @@ public class TEPottery extends NetworkTileEntity implements IInventory
 
 	public boolean isValid()
 	{
-		boolean surroundSolids = TFC_Core.isNorthSolid(worldObj, xCoord, yCoord, zCoord - 1) &&
-				TFC_Core.isSouthSolid(worldObj, xCoord, yCoord, zCoord + 1) &&
-				TFC_Core.isEastSolid(worldObj, xCoord - 1, yCoord, zCoord) &&
-				TFC_Core.isWestSolid(worldObj, xCoord + 1, yCoord, zCoord);
+		boolean surroundSolids = TFC_Core.isNorthFaceSolid(worldObj, xCoord, yCoord, zCoord - 1) &&
+				TFC_Core.isSouthFaceSolid(worldObj, xCoord, yCoord, zCoord + 1) &&
+				TFC_Core.isEastFaceSolid(worldObj, xCoord - 1, yCoord, zCoord) &&
+				TFC_Core.isWestFaceSolid(worldObj, xCoord + 1, yCoord, zCoord);
 		return surroundSolids && worldObj.isSideSolid(xCoord, yCoord - 1, zCoord, ForgeDirection.UP);
 	}
 


### PR DESCRIPTION
Pit kilns were checking for solid blocks two blocks away instead of checking for solid sides one block away.  The result was the pit kiln being unable to stay lit in certain cases.

If you make a pit kiln with a single missing (or non-solid) block exactly two blocks away from the pottery block, the fire will eventually go out and the kiln will fail to reignite due to a logic bug.
