### PR TITLE
[0.79] Fixed shift click for Ceramic Vessels

### DIFF
--- a/src/Common/com/bioxx/tfc/Containers/ContainerVessel.java
+++ b/src/Common/com/bioxx/tfc/Containers/ContainerVessel.java
@@ -201,12 +201,14 @@ public class ContainerVessel extends ContainerTFC
 			ItemStack clickedStack = clickedSlot.getStack();
 			returnedStack = clickedStack.copy();
 
-			if (clickedIndex < 4)
+			if (clickedIndex < 4) {
 				if (!this.mergeItemStack(clickedStack, 4, inventorySlots.size(), true))
 					return null;
-			else if (clickedIndex >= 4 && clickedIndex < inventorySlots.size())
+			}
+			else if (clickedIndex >= 4 && clickedIndex < inventorySlots.size()) {
 				if (!this.mergeItemStack(clickedStack, 0, 4, false))
 					return null;
+			}
 
 			if (clickedStack.stackSize == 0)
 				clickedSlot.putStack((ItemStack)null);


### PR DESCRIPTION
Shift clicking items in or out of ceramic vessels does not work correctly, this patch just fixes the logical flow for transferring stacks in and out so it works now.

The "else" on line 207 was originally matching up with the "if" on line 205 and not 204 as it should have been.
