### PR TITLE
[0.79] Fixed horizontal log placement and oak/acacia texture overwrite bug

### DIFF
--- a/src/Common/com/bioxx/tfc/Blocks/Flora/BlockLogHoriz.java
+++ b/src/Common/com/bioxx/tfc/Blocks/Flora/BlockLogHoriz.java
@@ -10,6 +10,7 @@ import net.minecraft.util.IIcon;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 
+import com.bioxx.tfc.TFCBlocks;
 import com.bioxx.tfc.api.Constant.Global;
 
 import cpw.mods.fml.relauncher.Side;
@@ -28,26 +29,27 @@ public class BlockLogHoriz extends BlockLogVert
 	}
 
 	@Override
+	@SideOnly(Side.CLIENT)
 	public IIcon getIcon(int side, int meta)
 	{
-		meta = (meta & 7) + offset;
 		int dir = meta >> 3;
+		meta = (meta & 7) + offset;
 
 		if(dir == 0)
 		{
 			if(side == 0 || side == 1)
-				return BlockLogNatural.sideIcons[meta];
+				return ((BlockLogNatural)TFCBlocks.LogNatural).sideIcons[meta];
 			else if(side == 2 || side == 3)
-				return BlockLogNatural.innerIcons[meta];
+				return ((BlockLogNatural)TFCBlocks.LogNatural).innerIcons[meta];
 			else
-				return BlockLogNatural.rotatedSideIcons[meta];
+				return ((BlockLogNatural)TFCBlocks.LogNatural).rotatedSideIcons[meta];
 		}
 		else
 		{
 			if(side == 0 || side == 1 || side == 2 || side == 3)
-				return BlockLogNatural.rotatedSideIcons[meta];
+				return ((BlockLogNatural)TFCBlocks.LogNatural).rotatedSideIcons[meta];
 			else
-				return BlockLogNatural.innerIcons[meta];
+				return ((BlockLogNatural)TFCBlocks.LogNatural).innerIcons[meta];
 		}
 	}
 

--- a/src/Common/com/bioxx/tfc/Blocks/Flora/BlockLogHoriz2.java
+++ b/src/Common/com/bioxx/tfc/Blocks/Flora/BlockLogHoriz2.java
@@ -2,7 +2,11 @@ package com.bioxx.tfc.Blocks.Flora;
 
 import net.minecraft.util.IIcon;
 
+import com.bioxx.tfc.TFCBlocks;
 import com.bioxx.tfc.api.Constant.Global;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 
 public class BlockLogHoriz2 extends BlockLogHoriz
 {
@@ -15,26 +19,27 @@ public class BlockLogHoriz2 extends BlockLogHoriz
 	}
 
 	@Override
+	@SideOnly(Side.CLIENT)
 	public IIcon getIcon(int side, int meta)
 	{
-		meta = (meta & 7) + offset;
 		int dir = meta >> 3;
+		meta = (meta & 7) + offset;
 
 		if(dir == 0)
 		{
 			if(side == 0 || side == 1)
-				return BlockLogNatural2.sideIcons[meta];
+				return ((BlockLogNatural2)TFCBlocks.LogNatural2).sideIcons[meta];
 			else if(side == 2 || side == 3)
-				return BlockLogNatural2.innerIcons[meta];
+				return ((BlockLogNatural2)TFCBlocks.LogNatural2).innerIcons[meta];
 			else
-				return BlockLogNatural2.rotatedSideIcons[meta];
+				return ((BlockLogNatural2)TFCBlocks.LogNatural2).rotatedSideIcons[meta];
 		}
 		else
 		{
 			if(side == 0 || side == 1 || side == 2 || side == 3)
-				return BlockLogNatural2.rotatedSideIcons[meta];
+				return ((BlockLogNatural2)TFCBlocks.LogNatural2).rotatedSideIcons[meta];
 			else
-				return BlockLogNatural2.innerIcons[meta];
+				return ((BlockLogNatural2)TFCBlocks.LogNatural2).innerIcons[meta];
 		}
 	}
 

--- a/src/Common/com/bioxx/tfc/Blocks/Flora/BlockLogNatural.java
+++ b/src/Common/com/bioxx/tfc/Blocks/Flora/BlockLogNatural.java
@@ -32,9 +32,9 @@ public class BlockLogNatural extends BlockTerra
 	int searchDist = 10;
 	static int damage = 0;
 	boolean isStone = false;
-	public static IIcon[] sideIcons;
-	public static IIcon[] innerIcons;
-	public static IIcon[] rotatedSideIcons;
+	public IIcon[] sideIcons;
+	public IIcon[] innerIcons;
+	public IIcon[] rotatedSideIcons;
 
 	public BlockLogNatural()
 	{
@@ -98,6 +98,7 @@ public class BlockLogNatural extends BlockTerra
 	}
 
 	@Override
+	@SideOnly(Side.CLIENT)
 	public IIcon getIcon(int side, int meta)
 	{
 		if (side == 1)

--- a/src/Common/com/bioxx/tfc/Blocks/Flora/BlockLogVert.java
+++ b/src/Common/com/bioxx/tfc/Blocks/Flora/BlockLogVert.java
@@ -13,6 +13,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.World;
 
+import com.bioxx.tfc.TFCBlocks;
 import com.bioxx.tfc.TFCItems;
 import com.bioxx.tfc.Blocks.BlockTerra;
 import com.bioxx.tfc.Core.Recipes;
@@ -87,13 +88,10 @@ public class BlockLogVert extends BlockTerra
 	}
 
 	@Override
+	@SideOnly(Side.CLIENT)
 	public IIcon getIcon(int side, int meta)
 	{
-		if (side == 1)
-			return BlockLogNatural.innerIcons[meta];
-		if (side == 0)
-			return BlockLogNatural.innerIcons[meta];
-		return BlockLogNatural.sideIcons[meta];
+		return TFCBlocks.LogNatural.getIcon(side, meta);
 	}
 
 	@SideOnly(Side.CLIENT)

--- a/src/Common/com/bioxx/tfc/Blocks/Flora/BlockLogVert2.java
+++ b/src/Common/com/bioxx/tfc/Blocks/Flora/BlockLogVert2.java
@@ -2,7 +2,11 @@ package com.bioxx.tfc.Blocks.Flora;
 
 import net.minecraft.util.IIcon;
 
+import com.bioxx.tfc.TFCBlocks;
 import com.bioxx.tfc.api.Constant.Global;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 
 public class BlockLogVert2 extends BlockLogVert
 {
@@ -20,12 +24,9 @@ public class BlockLogVert2 extends BlockLogVert
 	}
 
 	@Override
+	@SideOnly(Side.CLIENT)
 	public IIcon getIcon(int side, int meta)
 	{
-		if (side == 1)
-			return BlockLogNatural2.innerIcons[meta];
-		if (side == 0)
-			return BlockLogNatural2.innerIcons[meta];
-		return BlockLogNatural2.sideIcons[meta];
+		return TFCBlocks.LogNatural2.getIcon(side, meta);
 	}
 }

--- a/src/Common/com/bioxx/tfc/Items/ItemLogs.java
+++ b/src/Common/com/bioxx/tfc/Items/ItemLogs.java
@@ -132,7 +132,7 @@ public class ItemLogs extends ItemTerra
 
 	@Override
 	public IIcon getIconFromDamage(int meta)
-	{        
+	{
 		return icons[meta];
 	}
 
@@ -151,10 +151,10 @@ public class ItemLogs extends ItemTerra
 	{
 		if(!world.isRemote)
 		{
-			int dir = MathHelper.floor_double(entityplayer.rotationYaw * 4F / 360F + 0.5D) & 3;
 
 			if(entityplayer.isSneaking() && (world.getBlock(x, y, z) != TFCBlocks.LogPile || (side != 1 && side != 0)))
 			{
+				int dir = MathHelper.floor_double(entityplayer.rotationYaw * 4F / 360F + 0.5D) & 3;
 				if(CreatePile(itemstack, entityplayer, world, x, y, z, side, dir)) {
 					itemstack.stackSize = itemstack.stackSize-1;
 				}
@@ -177,12 +177,13 @@ public class ItemLogs extends ItemTerra
 						te.injectContents(2,1);
 					} else if(te.storage[2] == null) {
 						te.addContents(2, new ItemStack(this,1, itemstack.getItemDamage()));
-					} else if(te.storage[3] != null  && te.contentsMatch(3,itemstack)) {
+					} else if(te.storage[3] != null && te.contentsMatch(3,itemstack)) {
 						te.injectContents(3,1);
 					} else if(te.storage[3] == null) {
 						te.addContents(3, new ItemStack(this,1, itemstack.getItemDamage()));
 					} else
 					{
+						int dir = MathHelper.floor_double(entityplayer.rotationYaw * 4F / 360F + 0.5D) & 3;
 						if(CreatePile(itemstack, entityplayer, world, x, y, z, side, dir)) {
 							itemstack.stackSize = itemstack.stackSize-1;
 						}
@@ -199,31 +200,32 @@ public class ItemLogs extends ItemTerra
 			{
 				int m = itemstack.getItemDamage();
 				Block block = m>15?TFCBlocks.WoodVert2:TFCBlocks.WoodVert;
-				if(side == 1)
-				{
-					world.setBlock(x, y+1, z, block, m,0x2);
-					itemstack.stackSize = itemstack.stackSize-1;
-				}
-				else if(side == 0 && world.isAirBlock(x, y-1, z))
+
+				if(side == 0 && block.canPlaceBlockAt(world, x, y-1, z))
 				{
 					world.setBlock(x, y-1, z, block, m,0x2);
 					itemstack.stackSize = itemstack.stackSize-1;
 				}
-				else if(side == 2 && world.isAirBlock(x, y, z-1))
+				else if(side == 1 && block.canPlaceBlockAt(world, x, y+1, z))
 				{
-					setSide(world, itemstack, m, dir, x, y, z, 0, 0, -1);
+					world.setBlock(x, y+1, z, block, m,0x2);
+					itemstack.stackSize = itemstack.stackSize-1;
 				}
-				else if(side == 3 && world.isAirBlock(x, y, z+1))
+				else if(side == 2 && block.canPlaceBlockAt(world, x, y, z-1))
 				{
-					setSide(world, itemstack, m, dir, x, y, z, 0, 0, 1);
+					setSide(world, itemstack, m, side, x, y, z-1);
 				}
-				else if(side == 4 && world.isAirBlock(x-1, y, z))
+				else if(side == 3 && block.canPlaceBlockAt(world, x, y, z+1))
 				{
-					setSide(world, itemstack, m, dir, x, y, z, -1, 0, 0);
+					setSide(world, itemstack, m, side, x, y, z+1);
 				}
-				else if(side == 5 && world.isAirBlock(x+1, y, z))
+				else if(side == 4 && block.canPlaceBlockAt(world, x-1, y, z))
 				{
-					setSide(world, itemstack, m, dir, x, y, z, 1, 0, 0);
+					setSide(world, itemstack, m, side, x-1, y, z);
+				}
+				else if(side == 5 && block.canPlaceBlockAt(world, x+1, y, z))
+				{
+					setSide(world, itemstack, m, side, x+1, y, z);
 				}
 				return true;
 			}
@@ -231,46 +233,34 @@ public class ItemLogs extends ItemTerra
 		return false;
 	}
 
-	public void setSide(World world, ItemStack itemstack, int m, int dir, int x, int y, int z, int i, int j, int k)
+	public void setSide(World world, ItemStack itemstack, int m, int side, int x, int y, int z)
 	{
-		if(m < 8)
-		{
-			if(dir == 0 || dir == 2) {
-				world.setBlock(x+i, y+j, z+k, TFCBlocks.WoodHoriz, m, 0x2);
-			} else {
-				world.setBlock(x+i, y+j, z+k, TFCBlocks.WoodHoriz, m | 8, 0x2);
-			}
+		// don't call this function with side==0 or side==1, it won't do anything
+
+		int meta = m % 8;
+		Block log = TFCBlocks.WoodHoriz;
+		switch (m/8) {
+			case 0:
+				log = TFCBlocks.WoodHoriz;
+				break;
+			case 1:
+				log = TFCBlocks.WoodHoriz2;
+				break;
+			case 2:
+				log = TFCBlocks.WoodHoriz3;
+				break;
+			case 3:
+				log = TFCBlocks.WoodHoriz4;
+				break;
+		}
+
+		if (side == 2 || side == 3) {
+			world.setBlock(x, y, z, log, meta, 0x2);
 			itemstack.stackSize = itemstack.stackSize-1;
 		}
-		else if(m >= 8 && m<16)
-		{
-			if(dir == 0 || dir == 2) {
-				world.setBlock(x+i, y+j, z+k, TFCBlocks.WoodHoriz2, m-8, 0x2);
-			} else {
-				world.setBlock(x+i, y+j, z+k, TFCBlocks.WoodHoriz2, m-8 | 8, 0x2);
-			}
-			itemstack.stackSize = itemstack.stackSize-1;
-		}
-		else if(m < 24)
-		{
-			m-=16;
-			if(dir == 0 || dir == 2) {
-				world.setBlock(x+i, y+j, z+k, TFCBlocks.WoodHoriz3, m, 0x2);
-			} else {
-				world.setBlock(x+i, y+j, z+k, TFCBlocks.WoodHoriz3, m | 8, 0x2);
-			}
-			itemstack.stackSize = itemstack.stackSize-1;
-		}
-		else if(m >= 24 && m<32)
-		{
-			m-=16;
-			if(dir == 0 || dir == 2) {
-				world.setBlock(x+i, y+j, z+k, TFCBlocks.WoodHoriz4, m-8, 0x2);
-			} else {
-				world.setBlock(x+i, y+j, z+k, TFCBlocks.WoodHoriz4, m-8 | 8, 0x2);
-			}
+		else if (side == 4 || side == 5) {
+			world.setBlock(x, y, z, log, meta | 8, 0x2);
 			itemstack.stackSize = itemstack.stackSize-1;
 		}
 	}
-
 }


### PR DESCRIPTION
So this is two bug fixes at once and two additional behaviour update (which I know isn't a terribly good idea).

Bug 1) Horizontal logs were always being placed with the same orientation regardless of how/where you placed them.
I tracked this one down to BlockLogHoriz:34 and BlockLogHoriz2:25, the direction of the log was calculated after a metadata transform had removed the orientation information, I told it to calculate the direction first, then the metadata and they were aligned correctly.

Bug 2) Oak logs were using the Acacia textures.
This one is also pretty simple but there are a lot of changes to make it work.  BlockLogNatural declared its icons as static, so BlockLogNatural2 was using the exact same variables.  The result was the acacia textures loaded into the oak slots.  I made the icons non-static to fix it, and had to change all references to BlockLogNatural.<side>icon -> TFCBlocks.LogNatural.<side>icon (and the same for LogNatural2).  The vertical logs just directly call BlockLogNatural.getIcon() since they don't have to worry about orientation.  I also added some sideonly annotations to getIcon functions.

Behaviour update 1) Logs were checking for air blocks on placement, I changed it to check for replaceable blocks so they can now overwrite grass.  This is visible in ItemLogs:202-228.  This should also affect log placement in water/lava.

Behaviour update 2) Logs were using the players facing to calculate their orientation, but vanilla logs use the side you clicked on, so to be consistent with vanilla, I changed log placement to use the clicked side.  As a result I was able to shorten the ItemLogs:setSide function.

I can break this apart into multiple PRs or removed some of the behavioural updates if so desired.
