### PR TITLE
[0.79] Fixed crucible NBT synchronization and metal amount/ratio display in gui

### DIFF
--- a/src/Common/com/bioxx/tfc/Core/Metal/Alloy.java
+++ b/src/Common/com/bioxx/tfc/Core/Metal/Alloy.java
@@ -179,8 +179,8 @@ public class Alloy
 		{
 			NBTTagCompound nbt1 = new NBTTagCompound();
 			AlloyMetal am = AlloyIngred.get(i);
-			nbt.setString("metalType", am.metalType.Name);
-			nbt.setFloat("metalType", am.metal);
+			nbt1.setString("metalType", am.metalType.Name);
+			nbt1.setFloat("amount", am.metal);
 			nbtlist.appendTag(nbt1);
 		}
 		nbt.setTag("metalList", nbtlist);

--- a/src/Common/com/bioxx/tfc/GUI/GuiCrucible.java
+++ b/src/Common/com/bioxx/tfc/GUI/GuiCrucible.java
@@ -1,5 +1,8 @@
 package com.bioxx.tfc.GUI;
 
+import java.util.Arrays;
+import java.util.List;
+
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.entity.player.InventoryPlayer;
@@ -47,7 +50,6 @@ public class GuiCrucible extends GuiContainer
 
 		scale = te.getOutCountScaled(100);
 		drawTexturedModalRect(w + 129, h + 106 - scale, 177, 6, 8, scale);
-		
 
 		PlayerInventory.drawInventory(this, width, height, ySize-PlayerInventory.invYSize);
 
@@ -85,10 +87,22 @@ public class GuiCrucible extends GuiContainer
 	}
 
 	@Override
+	public void drawScreen(int par1, int par2, float par3) {
+		super.drawScreen(par1, par2, par3);
+		if (te.currentAlloy != null) {
+			int w = (this.width - this.xSize) / 2;
+			int h = (this.height - this.ySize) / 2;
+			if (par1 >= 129 + w && par2 >= 6 + h&& par1 <= 137 + w && par2 <= 106 + h) {
+				String[] text = { String.format("%2.0f", te.currentAlloy.outputAmount) };
+				List temp = Arrays.asList(text);
+				drawHoveringText(temp, par1, par2, fontRendererObj);
+			}
+		}
+	}
+
+	@Override
 	public void drawCenteredString(FontRenderer fontrenderer, String s, int i, int j, int k)
 	{
 		fontrenderer.drawString(s, i - fontrenderer.getStringWidth(s) / 2, j, k);
 	}
-
-
 }

--- a/src/Common/com/bioxx/tfc/TileEntities/TECrucible.java
+++ b/src/Common/com/bioxx/tfc/TileEntities/TECrucible.java
@@ -396,14 +396,21 @@ public class TECrucible extends NetworkTileEntity implements IInventory
 		{
 			NBTTagCompound nbt = new NBTTagCompound();
 			nbt.setByte("action", action);
+			if (currentAlloy != null) {
+				if (action == 0) {
+				  currentAlloy.toNBT(nbt);
+				}
+				else if (action == 1) {
+				  nbt.setFloat("outputAmount", currentAlloy.outputAmount);
+				}
+			}
 			this.broadcastPacketInRange(this.createDataPacket(nbt));
 		}
 	}
 
 	@Override
-	public void handleInitPacket(NBTTagCompound nbt) 
+	public void handleInitPacket(NBTTagCompound nbt)
 	{
-
 	}
 
 	@Override


### PR DESCRIPTION
There were a couple of annoying bugs preventing the crucible from working correctly.

1) Alloys inside them were not properly saving themselves to NBT.
2) The crucible was not actually writing its alloy to NBT.

As a side note, crucibles/metals are writing their amounts as floats but they are always integers, fixing this would cause compatibility problems, so I left it in.
