### PR TITLE
[0.79] Replaced deprecated Vec3.fakePool.getVecFromPool and AxisAlignedBB.getAABBPool

### DIFF
--- a/src/Common/com/bioxx/tfc/Blocks/BlockStalactite.java
+++ b/src/Common/com/bioxx/tfc/Blocks/BlockStalactite.java
@@ -91,7 +91,7 @@ public class BlockStalactite extends BlockTerra
 				height = 0.5f + R.nextFloat() * 0.5f;
 			else height = 1;
 
-			return AxisAlignedBB.getAABBPool().getAABB(i + width, j - height, k + width, i + 1 - width, j + 1, k + 1 - width);
+			return AxisAlignedBB.getBoundingBox(i + width, j - height, k + width, i + 1 - width, j + 1, k + 1 - width);
 		}
 		else if(isStalag)
 		{
@@ -101,10 +101,10 @@ public class BlockStalactite extends BlockTerra
 			if(height == 3)
 				height = 0.5f + R.nextFloat() * 0.5f;
 			else height = 1;
-			return AxisAlignedBB.getAABBPool().getAABB(i+ width, j, k + width, i + 1-width, j+height, k + 1 - width);
+			return AxisAlignedBB.getBoundingBox(i+ width, j, k + width, i + 1-width, j+height, k + 1 - width);
 		}
 
-		return AxisAlignedBB.getAABBPool().getAABB(i + this.minX, j + this.minY, k + this.minZ, i + this.maxX, j+this.maxY, k + this.maxZ);
+		return AxisAlignedBB.getBoundingBox(i + this.minX, j + this.minY, k + this.minZ, i + this.maxX, j+this.maxY, k + this.maxZ);
 	}
 
 	@Override

--- a/src/Common/com/bioxx/tfc/Blocks/Vanilla/BlockCustomCactus.java
+++ b/src/Common/com/bioxx/tfc/Blocks/Vanilla/BlockCustomCactus.java
@@ -75,7 +75,7 @@ public class BlockCustomCactus extends Block implements IPlantable
 	public AxisAlignedBB getCollisionBoundingBoxFromPool(World par1World, int par2, int par3, int par4)
 	{
 		float var5 = 0.0625F;
-		return AxisAlignedBB.getAABBPool().getAABB((double)((float)par2 + var5), (double)par3, (double)((float)par4 + var5), (double)((float)(par2 + 1) - var5), (double)((float)(par3 + 1) - var5), (double)((float)(par4 + 1) - var5));
+		return AxisAlignedBB.getBoundingBox((double)((float)par2 + var5), (double)par3, (double)((float)par4 + var5), (double)((float)(par2 + 1) - var5), (double)((float)(par3 + 1) - var5), (double)((float)(par4 + 1) - var5));
 	}
 
 	@SideOnly(Side.CLIENT)
@@ -86,7 +86,7 @@ public class BlockCustomCactus extends Block implements IPlantable
 	public AxisAlignedBB getSelectedBoundingBoxFromPool(World par1World, int par2, int par3, int par4)
 	{
 		float var5 = 0.0625F;
-		return AxisAlignedBB.getAABBPool().getAABB((double)((float)par2 + var5), (double)par3, (double)((float)par4 + var5), (double)((float)(par2 + 1) - var5), (double)(par3 + 1), (double)((float)(par4 + 1) - var5));
+		return AxisAlignedBB.getBoundingBox((double)((float)par2 + var5), (double)par3, (double)((float)par4 + var5), (double)((float)(par2 + 1) - var5), (double)(par3 + 1), (double)((float)(par4 + 1) - var5));
 	}
 
 	/**

--- a/src/Common/com/bioxx/tfc/Blocks/Vanilla/BlockCustomFenceGate.java
+++ b/src/Common/com/bioxx/tfc/Blocks/Vanilla/BlockCustomFenceGate.java
@@ -46,7 +46,7 @@ public class BlockCustomFenceGate extends BlockFenceGate implements ITileEntityP
 	{
 		int l = (par1World.getTileEntity(par2, par3, par4)!=null)?(((TileEntityFenceGate)(par1World.getTileEntity(par2, par3, par4))).getDirection()):0;
 		boolean open = (par1World.getTileEntity(par2, par3, par4)!=null)?(((TileEntityFenceGate)(par1World.getTileEntity(par2, par3, par4))).getOpen()):false;
-		return open ? null : (l != 2 && l != 0 ? AxisAlignedBB.getAABBPool().getAABB((double)((float)par2 + 0.375F), (double)par3, (double)par4, (double)((float)par2 + 0.625F), (double)((float)par3 + 1.5F), (double)(par4 + 1)) : AxisAlignedBB.getAABBPool().getAABB((double)par2, (double)par3, (double)((float)par4 + 0.375F), (double)(par2 + 1), (double)((float)par3 + 1.5F), (double)((float)par4 + 0.625F)));
+		return open ? null : (l != 2 && l != 0 ? AxisAlignedBB.getBoundingBox((double)((float)par2 + 0.375F), (double)par3, (double)par4, (double)((float)par2 + 0.625F), (double)((float)par3 + 1.5F), (double)(par4 + 1)) : AxisAlignedBB.getBoundingBox((double)par2, (double)par3, (double)((float)par4 + 0.375F), (double)(par2 + 1), (double)((float)par3 + 1.5F), (double)((float)par4 + 0.625F)));
 	}
 
 	@SideOnly(Side.CLIENT)

--- a/src/Common/com/bioxx/tfc/Blocks/Vanilla/BlockCustomFenceGate2.java
+++ b/src/Common/com/bioxx/tfc/Blocks/Vanilla/BlockCustomFenceGate2.java
@@ -47,7 +47,7 @@ public class BlockCustomFenceGate2 extends BlockFenceGate implements ITileEntity
 	{
 		int l = (par1World.getTileEntity(par2, par3, par4)!=null)?(((TileEntityFenceGate)(par1World.getTileEntity(par2, par3, par4))).getDirection()):0;
 		boolean open = (par1World.getTileEntity(par2, par3, par4)!=null)?(((TileEntityFenceGate)(par1World.getTileEntity(par2, par3, par4))).getOpen()):false;
-		return open ? null : (l != 2 && l != 0 ? AxisAlignedBB.getAABBPool().getAABB((double)((float)par2 + 0.375F), (double)par3, (double)par4, (double)((float)par2 + 0.625F), (double)((float)par3 + 1.5F), (double)(par4 + 1)) : AxisAlignedBB.getAABBPool().getAABB((double)par2, (double)par3, (double)((float)par4 + 0.375F), (double)(par2 + 1), (double)((float)par3 + 1.5F), (double)((float)par4 + 0.625F)));
+		return open ? null : (l != 2 && l != 0 ? AxisAlignedBB.getBoundingBox((double)((float)par2 + 0.375F), (double)par3, (double)par4, (double)((float)par2 + 0.625F), (double)((float)par3 + 1.5F), (double)(par4 + 1)) : AxisAlignedBB.getBoundingBox((double)par2, (double)par3, (double)((float)par4 + 0.375F), (double)(par2 + 1), (double)((float)par3 + 1.5F), (double)((float)par4 + 0.625F)));
 	}
 
 	@SideOnly(Side.CLIENT)

--- a/src/Common/com/bioxx/tfc/Blocks/Vanilla/BlockCustomLilyPad.java
+++ b/src/Common/com/bioxx/tfc/Blocks/Vanilla/BlockCustomLilyPad.java
@@ -55,7 +55,7 @@ public class BlockCustomLilyPad extends BlockLilyPad
 	@Override
 	public AxisAlignedBB getCollisionBoundingBoxFromPool(World par1World, int par2, int par3, int par4)
 	{
-		return AxisAlignedBB.getAABBPool().getAABB((double)par2 + this.minX, (double)par3 + this.minY, (double)par4 + this.minZ, (double)par2 + this.maxX, (double)par3 + this.maxY, (double)par4 + this.maxZ);
+		return AxisAlignedBB.getBoundingBox((double)par2 + this.minX, (double)par3 + this.minY, (double)par4 + this.minZ, (double)par2 + this.maxX, (double)par3 + this.maxY, (double)par4 + this.maxZ);
 	}
 
 	@Override

--- a/src/Common/com/bioxx/tfc/Blocks/Vanilla/BlockCustomSnow.java
+++ b/src/Common/com/bioxx/tfc/Blocks/Vanilla/BlockCustomSnow.java
@@ -66,7 +66,7 @@ public class BlockCustomSnow extends BlockTerra
 	{
 		int l = world.getBlockMetadata(x, y, z) & 7;
 		float f = 0.125F;
-		return AxisAlignedBB.getAABBPool().getAABB(x + this.minX, y + this.minY, z + this.minZ, x + this.maxX, y + f, z + this.maxZ);
+		return AxisAlignedBB.getBoundingBox(x + this.minX, y + this.minY, z + this.minZ, x + this.maxX, y + f, z + this.maxZ);
 	}
 	@Override
 	public int getRenderType()

--- a/src/Common/com/bioxx/tfc/Entities/AI/EntityAIAvoidEntitySelectorTFC.java
+++ b/src/Common/com/bioxx/tfc/Entities/AI/EntityAIAvoidEntitySelectorTFC.java
@@ -21,7 +21,7 @@ class EntityAIAvoidEntitySelectorTFC implements IEntitySelector
 	{
 		EntityCreature creature = EntityAIAvoidEntityTFC.func_98217_a(this.entityAvoiderAI);
 		//TFC calculation for animal field-of-view. Generous in favour of approaching entity, with 340 degree FOV around the creature.
-		Vec3 distanceVec = Vec3.fakePool.getVecFromPool(creature.posX - par1Entity.posX,creature.posY - par1Entity.posY,creature.posZ - par1Entity.posZ);
+		Vec3 distanceVec = Vec3.createVectorHelper(creature.posX - par1Entity.posX,creature.posY - par1Entity.posY,creature.posZ - par1Entity.posZ);
 		double cosAngleAbs = Math.abs((distanceVec.dotProduct(creature.getLookVec())/(distanceVec.lengthVector() * creature.getLookVec().lengthVector())));
 		boolean fovSight = cosAngleAbs < 0.985;
 		//TFC calculation for motion-based sight. If entity is within FOV, RNG is used to see if entity will be spotted. 
@@ -29,7 +29,7 @@ class EntityAIAvoidEntitySelectorTFC implements IEntitySelector
 		//Entity motion also plays a role, affecting the maximum size of n and also the minimum, the first part of n is to make n >= 1
 		//this is relevant when the the entity is very close to the centre of the FOV, therefore motion is squared against 8, making minute movements
 		//more impactful on detection, however if the entity is spotted when it is not moving, it is not an instant spot success
-		Vec3 movement = Vec3.fakePool.getVecFromPool(par1Entity.motionX, par1Entity.motionY, par1Entity.motionZ);
+		Vec3 movement = Vec3.createVectorHelper(par1Entity.motionX, par1Entity.motionY, par1Entity.motionZ);
 		double inverseMotion = movement.lengthVector() > 0 ? 1D / (movement.lengthVector()*2):1;
 		inverseMotion = inverseMotion > 1? 1: inverseMotion;
 		int n = (int)(Math.ceil((8 * inverseMotion * inverseMotion))) + (int)((cosAngleAbs * 1.015)*30*inverseMotion);

--- a/src/Common/com/bioxx/tfc/Entities/EntityFishHookTFC.java
+++ b/src/Common/com/bioxx/tfc/Entities/EntityFishHookTFC.java
@@ -344,7 +344,7 @@ public class EntityFishHookTFC extends EntityFishHook
 				{
 					double d7 = this.boundingBox.minY + (this.boundingBox.maxY - this.boundingBox.minY) * (k + 0) / b0 - 0.125D + 0.125D;
 					double d8 = this.boundingBox.minY + (this.boundingBox.maxY - this.boundingBox.minY) * (k + 1) / b0 - 0.125D + 0.125D;
-					AxisAlignedBB axisalignedbb1 = AxisAlignedBB.getAABBPool().getAABB(this.boundingBox.minX, d7, this.boundingBox.minZ, this.boundingBox.maxX, d8, this.boundingBox.maxZ);
+					AxisAlignedBB axisalignedbb1 = AxisAlignedBB.getBoundingBox(this.boundingBox.minX, d7, this.boundingBox.minZ, this.boundingBox.maxX, d8, this.boundingBox.maxZ);
 
 					if (this.worldObj.isAABBInMaterial(axisalignedbb1, Material.water))
 						d6 += 1.0D / b0;

--- a/src/Common/com/bioxx/tfc/Entities/Mobs/EntityDeer.java
+++ b/src/Common/com/bioxx/tfc/Entities/Mobs/EntityDeer.java
@@ -215,7 +215,7 @@ public class EntityDeer extends EntityAnimal implements IAnimal
 		if(attackedVec != null)
 		{
 			//System.out.println(this.entityId+", Vec: "+attackedVec.xCoord+", "+attackedVec.yCoord+", "+attackedVec.zCoord);
-			Vec3 positionVec = Vec3.fakePool.getVecFromPool(this.posX, this.posY, this.posZ);
+			Vec3 positionVec = Vec3.createVectorHelper(this.posX, this.posY, this.posZ);
 			if(this.getFearSource() != null && this.getDistanceSqToEntity(this.getFearSource()) > 144)
 			{
 				this.setFearSource(null);
@@ -245,7 +245,7 @@ public class EntityDeer extends EntityAnimal implements IAnimal
 		Entity entity = par1DamageSource.getEntity();
 		if(entity != null)
 		{
-			setAttackedVec(Vec3.fakePool.getVecFromPool(entity.posX, entity.posY, entity.posZ));
+			setAttackedVec(Vec3.createVectorHelper(entity.posX, entity.posY, entity.posZ));
 			setFearSource(entity);
 		}
 		return super.attackEntityFrom(par1DamageSource, par2);

--- a/src/Common/com/bioxx/tfc/Handlers/Client/ArmourStandHighlightHandler.java
+++ b/src/Common/com/bioxx/tfc/Handlers/Client/ArmourStandHighlightHandler.java
@@ -132,20 +132,20 @@ public class ArmourStandHighlightHandler
 		unit = player.getLookVec();
 		aabb.minY+=0.1;
 		aabb.maxY+=0.1;
-		Vec3 playerVec = Vec3.fakePool.getVecFromPool(player.posX, player.posY + player.eyeHeight, player.posZ);
-		Vec3 negPlayerVec = Vec3.fakePool.getVecFromPool(-player.lastTickPosX, -(player.lastTickPosY + player.eyeHeight), -player.lastTickPosZ);
-		Vec3 zeroVec = Vec3.fakePool.getVecFromPool(0,0,0);
-		Vec3 distBlockxyz = (playerVec.subtract(Vec3.fakePool.getVecFromPool(aabb.minX,aabb.minY,aabb.minZ))).normalize();
-		Vec3 distBlockXYZ = (playerVec.subtract(Vec3.fakePool.getVecFromPool(aabb.maxX,aabb.maxY,aabb.maxZ))).normalize();
+		Vec3 playerVec = Vec3.createVectorHelper(player.posX, player.posY + player.eyeHeight, player.posZ);
+		Vec3 negPlayerVec = Vec3.createVectorHelper(-player.lastTickPosX, -(player.lastTickPosY + player.eyeHeight), -player.lastTickPosZ);
+		Vec3 zeroVec = Vec3.createVectorHelper(0,0,0);
+		Vec3 distBlockxyz = (playerVec.subtract(Vec3.createVectorHelper(aabb.minX,aabb.minY,aabb.minZ))).normalize();
+		Vec3 distBlockXYZ = (playerVec.subtract(Vec3.createVectorHelper(aabb.maxX,aabb.maxY,aabb.maxZ))).normalize();
 
-		Vec3 distBlockxyZ = (playerVec.subtract(Vec3.fakePool.getVecFromPool(aabb.minX,aabb.minY,aabb.maxZ))).normalize();
-		Vec3 distBlockXYz = (playerVec.subtract(Vec3.fakePool.getVecFromPool(aabb.maxX,aabb.maxY,aabb.minZ))).normalize();
+		Vec3 distBlockxyZ = (playerVec.subtract(Vec3.createVectorHelper(aabb.minX,aabb.minY,aabb.maxZ))).normalize();
+		Vec3 distBlockXYz = (playerVec.subtract(Vec3.createVectorHelper(aabb.maxX,aabb.maxY,aabb.minZ))).normalize();
 
-		Vec3 distBlockxYZ = (playerVec.subtract(Vec3.fakePool.getVecFromPool(aabb.minX,aabb.maxY,aabb.maxZ))).normalize();
-		Vec3 distBlockXyz = (playerVec.subtract(Vec3.fakePool.getVecFromPool(aabb.maxX,aabb.minY,aabb.minZ))).normalize();
+		Vec3 distBlockxYZ = (playerVec.subtract(Vec3.createVectorHelper(aabb.minX,aabb.maxY,aabb.maxZ))).normalize();
+		Vec3 distBlockXyz = (playerVec.subtract(Vec3.createVectorHelper(aabb.maxX,aabb.minY,aabb.minZ))).normalize();
 
-		Vec3 distBlockxYz = (playerVec.subtract(Vec3.fakePool.getVecFromPool(aabb.minX,aabb.maxY,aabb.minZ))).normalize();
-		Vec3 distBlockXyZ = (playerVec.subtract(Vec3.fakePool.getVecFromPool(aabb.maxX,aabb.minY,aabb.maxZ))).normalize();
+		Vec3 distBlockxYz = (playerVec.subtract(Vec3.createVectorHelper(aabb.minX,aabb.maxY,aabb.minZ))).normalize();
+		Vec3 distBlockXyZ = (playerVec.subtract(Vec3.createVectorHelper(aabb.maxX,aabb.minY,aabb.maxZ))).normalize();
 			//To ensure that the unit vector is actually within the space, we project the vectors onto it, and make the total length that length
 			double currentLongestProj = 0;
 			currentLongestProj = Math.max(currentLongestProj, unit.dotProduct(distBlockxyz));

--- a/src/Common/com/bioxx/tfc/Handlers/Client/ChiselHighlightHandler.java
+++ b/src/Common/com/bioxx/tfc/Handlers/Client/ChiselHighlightHandler.java
@@ -69,7 +69,7 @@ public class ChiselHighlightHandler
 				GL11.glLineWidth(4.0F);
 				GL11.glDepthMask(true);
 				//Draw the mini Box
-				drawOutlinedBoundingBox(AxisAlignedBB.getAABBPool().getAABB(minX,minY,minZ,maxX,maxY,maxZ).expand(0.002F, 0.002F, 0.002F).getOffsetBoundingBox(-var8, -var10, -var12));
+				drawOutlinedBoundingBox(AxisAlignedBB.getBoundingBox(minX,minY,minZ,maxX,maxY,maxZ).expand(0.002F, 0.002F, 0.002F).getOffsetBoundingBox(-var8, -var10, -var12));
 
 				GL11.glDepthMask(true);
 				GL11.glEnable(GL11.GL_TEXTURE_2D);

--- a/src/Common/com/bioxx/tfc/Handlers/Client/FarmlandHighlightHandler.java
+++ b/src/Common/com/bioxx/tfc/Handlers/Client/FarmlandHighlightHandler.java
@@ -74,7 +74,7 @@ public class FarmlandHighlightHandler
 				double offset = 0;
 				double fertilizer = 1.02 + ((double)te.nutrients[3] / (double)soilMax)*0.5;
 				GL11.glColor4ub(TFCOptions.cropFertilizerColor[0], TFCOptions.cropFertilizerColor[1], TFCOptions.cropFertilizerColor[2], TFCOptions.cropFertilizerColor[3]);
-				drawBox(AxisAlignedBB.getAABBPool().getAABB(
+				drawBox(AxisAlignedBB.getBoundingBox(
 						evt.target.blockX + offset,
 						evt.target.blockY + 1.01 - crop,
 						evt.target.blockZ,
@@ -85,7 +85,7 @@ public class FarmlandHighlightHandler
 
 				double nutrient = 1.02 + ((double)te.nutrients[0] / (double)soilMax) * 0.5;
 				GL11.glColor4ub(TFCOptions.cropNutrientAColor[0], TFCOptions.cropNutrientAColor[1], TFCOptions.cropNutrientAColor[2], TFCOptions.cropNutrientAColor[3]);
-				drawBox(AxisAlignedBB.getAABBPool().getAABB(
+				drawBox(AxisAlignedBB.getBoundingBox(
 						evt.target.blockX + offset,
 						evt.target.blockY + 1.01 - crop + fertilizer - 1.02,
 						evt.target.blockZ,
@@ -97,7 +97,7 @@ public class FarmlandHighlightHandler
 				offset = 0.3333;
 				nutrient = 1.02 + ((double)te.nutrients[1] / (double)soilMax) * 0.5;
 				GL11.glColor4ub(TFCOptions.cropNutrientBColor[0], TFCOptions.cropNutrientBColor[1], TFCOptions.cropNutrientBColor[2], TFCOptions.cropNutrientBColor[3]);
-				drawBox(AxisAlignedBB.getAABBPool().getAABB(
+				drawBox(AxisAlignedBB.getBoundingBox(
 						evt.target.blockX + offset,
 						evt.target.blockY + 1.01 - crop + fertilizer - 1.02,
 						evt.target.blockZ,
@@ -109,7 +109,7 @@ public class FarmlandHighlightHandler
 				offset = 0.6666;
 				nutrient = 1.02 + ((double)te.nutrients[2] / (double)soilMax) * 0.5;
 				GL11.glColor4ub(TFCOptions.cropNutrientCColor[0], TFCOptions.cropNutrientCColor[1], TFCOptions.cropNutrientCColor[2], TFCOptions.cropNutrientCColor[3]);
-				drawBox(AxisAlignedBB.getAABBPool().getAABB(
+				drawBox(AxisAlignedBB.getBoundingBox(
 						evt.target.blockX + offset,
 						evt.target.blockY + 1.01 - crop + fertilizer - 1.02,
 						evt.target.blockZ,
@@ -131,7 +131,7 @@ public class FarmlandHighlightHandler
 
 				offset = 0;
 
-				drawOutlinedBoundingBox(AxisAlignedBB.getAABBPool().getAABB(
+				drawOutlinedBoundingBox(AxisAlignedBB.getBoundingBox(
 						evt.target.blockX + offset,
 						evt.target.blockY + 1.01 - crop,
 						evt.target.blockZ,
@@ -141,7 +141,7 @@ public class FarmlandHighlightHandler
 						).expand(0.002F, 0.002F, 0.002F).getOffsetBoundingBox(-var8, -var10, -var12));
 
 				nutrient = 1.02 + ((double)te.nutrients[0] / (double)soilMax) * 0.5;
-				drawOutlinedBoundingBox(AxisAlignedBB.getAABBPool().getAABB(
+				drawOutlinedBoundingBox(AxisAlignedBB.getBoundingBox(
 						evt.target.blockX + offset,
 						evt.target.blockY + 1.01 - crop + fertilizer - 1.02,
 						evt.target.blockZ,
@@ -152,7 +152,7 @@ public class FarmlandHighlightHandler
 
 				offset = 0.3333;
 				nutrient = 1.02 + ((double)te.nutrients[1] / (double)soilMax) * 0.5;
-				drawOutlinedBoundingBox(AxisAlignedBB.getAABBPool().getAABB(
+				drawOutlinedBoundingBox(AxisAlignedBB.getBoundingBox(
 						evt.target.blockX + offset,
 						evt.target.blockY + 1.01 - crop + fertilizer - 1.02,
 						evt.target.blockZ,
@@ -163,7 +163,7 @@ public class FarmlandHighlightHandler
 
 				offset = 0.6666;
 				nutrient = 1.02 + ((double)te.nutrients[2] / (double)soilMax) * 0.5;
-				drawOutlinedBoundingBox(AxisAlignedBB.getAABBPool().getAABB(
+				drawOutlinedBoundingBox(AxisAlignedBB.getBoundingBox(
 						evt.target.blockX + offset,
 						evt.target.blockY + 1.01 - crop + fertilizer - 1.02,
 						evt.target.blockZ,
@@ -201,7 +201,7 @@ public class FarmlandHighlightHandler
 				GL11.glDisable(GL11.GL_TEXTURE_2D);
 				GL11.glDepthMask(false);
 
-				drawFace(AxisAlignedBB.getAABBPool().getAABB(
+				drawFace(AxisAlignedBB.getBoundingBox(
 						evt.target.blockX,
 						evt.target.blockY + 1.01 - crop,
 						evt.target.blockZ,
@@ -236,7 +236,7 @@ public class FarmlandHighlightHandler
 				GL11.glDisable(GL11.GL_TEXTURE_2D);
 				GL11.glDepthMask(false);
 
-				drawFace(AxisAlignedBB.getAABBPool().getAABB(
+				drawFace(AxisAlignedBB.getBoundingBox(
 						evt.target.blockX,
 						evt.target.blockY + 0.01,
 						evt.target.blockZ,

--- a/src/Common/com/bioxx/tfc/Handlers/Client/PlankHighlightHandler.java
+++ b/src/Common/com/bioxx/tfc/Handlers/Client/PlankHighlightHandler.java
@@ -143,7 +143,7 @@ public class PlankHighlightHandler{
 			GL11.glDisable(GL11.GL_CULL_FACE);
 			GL11.glDepthMask(false);
 			//Draw the mini Box
-			drawBox(AxisAlignedBB.getAABBPool().getAABB(minX,minY,minZ,maxX,maxY,maxZ).expand(0.002F, 0.002F, 0.002F).getOffsetBoundingBox(-var8, -var10, -var12));
+			drawBox(AxisAlignedBB.getBoundingBox(minX,minY,minZ,maxX,maxY,maxZ).expand(0.002F, 0.002F, 0.002F).getOffsetBoundingBox(-var8, -var10, -var12));
 
 			GL11.glDepthMask(true);
 			GL11.glEnable(GL11.GL_TEXTURE_2D);

--- a/src/Common/com/bioxx/tfc/Items/ItemCustomLeash.java
+++ b/src/Common/com/bioxx/tfc/Items/ItemCustomLeash.java
@@ -61,7 +61,7 @@ public class ItemCustomLeash extends ItemLead implements ISize
 		EntityLeashKnot entityleashknot = EntityLeashKnot.getKnotForBlock(par1World, par2, par3, par4);
 		boolean flag = false;
 		double d0 = 7.0D;
-		List list = par1World.getEntitiesWithinAABB(EntityLiving.class, AxisAlignedBB.getAABBPool().getAABB((double)par2 - d0, (double)par3 - d0, (double)par4 - d0, (double)par2 + d0, (double)par3 + d0, (double)par4 + d0));
+		List list = par1World.getEntitiesWithinAABB(EntityLiving.class, AxisAlignedBB.getBoundingBox((double)par2 - d0, (double)par3 - d0, (double)par4 - d0, (double)par2 + d0, (double)par3 + d0, (double)par4 + d0));
 
 		if (list != null)
 		{

--- a/src/Common/com/bioxx/tfc/TileEntities/TEChest.java
+++ b/src/Common/com/bioxx/tfc/TileEntities/TEChest.java
@@ -243,7 +243,7 @@ public class TEChest extends TileEntityChest implements IInventory
 		{
 			this.numPlayersUsing = 0;
 			float f = 5.0F;
-			List list = this.worldObj.getEntitiesWithinAABB(EntityPlayer.class, AxisAlignedBB.getAABBPool().getAABB(this.xCoord - f, this.yCoord - f, this.zCoord - f, this.xCoord + 1 + f, this.yCoord + 1 + f, this.zCoord + 1 + f));
+			List list = this.worldObj.getEntitiesWithinAABB(EntityPlayer.class, AxisAlignedBB.getBoundingBox(this.xCoord - f, this.yCoord - f, this.zCoord - f, this.xCoord + 1 + f, this.yCoord + 1 + f, this.zCoord + 1 + f));
 			Iterator iterator = list.iterator();
 
 			while (iterator.hasNext())
@@ -309,7 +309,7 @@ public class TEChest extends TileEntityChest implements IInventory
 	@SideOnly(Side.CLIENT)
 	public AxisAlignedBB getRenderBoundingBox()
 	{
-		AxisAlignedBB bb = AxisAlignedBB.getAABBPool().getAABB(xCoord - 1, yCoord, zCoord - 1, xCoord + 2, yCoord + 2, zCoord + 2);
+		AxisAlignedBB bb = AxisAlignedBB.getBoundingBox(xCoord - 1, yCoord, zCoord - 1, xCoord + 2, yCoord + 2, zCoord + 2);
 		return bb;
 	}
 


### PR DESCRIPTION
In 1.7.10 Lex has removed these two functions and replaced them like:
`Vec3.fakePool.getVecFromPool => Vec3.createVectorHelper`
`AxisAlignedBB.getAABBPool.getAABB => AxisAlignedBB.getBoundingBox`
These two new functions are available in 1.7.2, they are just deprecated as of forge#1120.
