### PR TITLE
[0.79] Removed unneeded overrides in BlockThatch

### DIFF
--- a/src/Common/com/bioxx/tfc/Blocks/BlockThatch.java
+++ b/src/Common/com/bioxx/tfc/Blocks/BlockThatch.java
@@ -38,64 +38,6 @@ public class BlockThatch extends BlockTerra
 	}
 
 	@Override
-	public IIcon getIcon(int side, int meta)
-	{
-		return this.blockIcon;
-	}
-
-	@Override
-	public boolean isOpaqueCube()
-	{
-		return true;
-	}
-
-	@Override
-	public boolean renderAsNormalBlock()
-	{
-		return true;
-	}
-
-	/**
-	 * Called whenever the block is added into the world. Args: world, x, y, z
-	 */
-	@Override
-	public void onBlockAdded(World par1World, int par2, int par3, int par4)
-	{
-		super.onBlockAdded(par1World, par2, par3, par4);
-	}
-
-	@Override
-	public void onBlockDestroyedByExplosion(World par1World, int par2, int par3, int par4, Explosion par5Explosion)
-	{
-	}
-
-	/**
-	 * Called when the block is placed in the world.
-	 */
-	@Override
-	public void onBlockPlacedBy(World par1World, int par2, int par3, int par4, EntityLivingBase par5EntityLiving, ItemStack is)
-	{
-	}
-
-	/**
-	 * Checks to see if its valid to put this block at the specified coordinates. Args: world, x, y, z
-	 */
-	@Override
-	public boolean canPlaceBlockAt(World par1World, int par2, int par3, int par4)
-	{
-		return true;
-	}
-
-	/**
-	 * Called whenever the block is removed.
-	 */
-	@Override
-	public void breakBlock(World par1World, int par2, int par3, int par4, Block par5, int par6)
-	{
-		super.breakBlock(par1World, par2, par3, par4, par5, par6);
-	}
-
-	@Override
 	public void harvestBlock(World world, EntityPlayer entityplayer, int i, int j, int k, int l)
 	{
 		//Random R = new Random();
@@ -103,21 +45,5 @@ public class BlockThatch extends BlockTerra
 
 		//super.harvestBlock(world, entityplayer, i, j, k, l);
 		dropBlockAsItem(world, i, j, k, new ItemStack(this, 1, l));
-	}
-
-	@Override
-	@SideOnly(Side.CLIENT)
-	public boolean addDestroyEffects(World world, int x, int y, int z, int meta, EffectRenderer effectRenderer)
-	{
-		// TODO Include particle spawning logic, or replace this with a functional getBlockTextureFromSideAndMetadata 
-		return true;
-	}
-
-	@Override
-	@SideOnly(Side.CLIENT)
-	public boolean addHitEffects(World worldObj, MovingObjectPosition target, EffectRenderer effectRenderer)
-	{
-		// TODO Include particle spawning logic, or replace this with a functional getBlockTextureFromSideAndMetadata 
-		return true;
 	}
 }


### PR DESCRIPTION
BlockThatch at a bunch of functions overridden from its base classes that added nothing to the block.  They made the class more complicated then it had to be and they caused the hit and break particles to malfunction.

None of these functions are needed, in fact harvestBlock is also not needed, but it does perform some shortcut calculations so I didn't touch it.

If BlockThatch is in fact supposed to override these functions for a future reason then ignore/close this.  Otherwise the code is just bloat.
