### PR TITLE
[0.79] Add a config option to toggle the witty calendar references

### DIFF
--- a/src/API/com/bioxx/tfc/api/TFCOptions.java
+++ b/src/API/com/bioxx/tfc/api/TFCOptions.java
@@ -26,6 +26,7 @@ public class TFCOptions
 	public static float saplingTimerMultiplier = 1.0f;
 	public static float tempIncreaseMultiplier = 1.0f;
 	public static float tempDecreaseMultiplier = 1.0f;
+	public static boolean enableWittyCalendar = true;
 
 	public static int maxProtectionMonths;
 	public static int protectionGain;

--- a/src/Common/com/bioxx/tfc/GUI/GuiCalendar.java
+++ b/src/Common/com/bioxx/tfc/GUI/GuiCalendar.java
@@ -102,9 +102,9 @@ public class GuiCalendar extends GuiScreen
 		int dom = TFC_Time.getDayOfMonth();
 		int month = TFC_Time.currentMonth;
 
-		if(dom == 7 && month == 4)
+		if(dom == 7 && month == 4 && TFCOptions.enableWittyCalendar)
 			drawCenteredString(fontRendererObj,StatCollector.translateToLocal("gui.Calendar.DateBioxx") + ", " +(1000+TFC_Time.getYear()), l + 87, i1+46, 0x000000);
-		else if(dom == 2 && month == 8)
+		else if(dom == 2 && month == 8 && TFCOptions.enableWittyCalendar)
 			drawCenteredString(fontRendererObj,StatCollector.translateToLocal("gui.Calendar.DateDunk") + ", " +(1000+TFC_Time.getYear()), l + 87, i1+46, 0x000000);
 		else
 			drawCenteredString(fontRendererObj,StatCollector.translateToLocal("gui.Calendar.Date") + " : " + dom + " " + TFC_Time.MONTHS[month] + ", " +(1000+TFC_Time.getYear()), l + 87, i1+46, 0x000000);
@@ -117,7 +117,7 @@ public class GuiCalendar extends GuiScreen
 
 		long h = TFC_Time.getHour();
 		String hour = "";
-		if(h == 0)
+		if(h == 0 && TFCOptions.enableWittyCalendar)
 			hour = StatCollector.translateToLocal("gui.Calendar.WitchHour");
 		else
 			hour+=h;

--- a/src/Common/com/bioxx/tfc/TerraFirmaCraft.java
+++ b/src/Common/com/bioxx/tfc/TerraFirmaCraft.java
@@ -297,6 +297,7 @@ public class TerraFirmaCraft
 		TFCOptions.saplingTimerMultiplier = (float) TFCOptions.getDoubleFor(config, "Time", "saplingTimerMultiplier", 1.0, "This is a global multiplier for the number of days required before a sapling can grow into a tree. Decrease for faster sapling growth.");
 		TFCOptions.tempIncreaseMultiplier = (float) TFCOptions.getDoubleFor(config, "Time", "tempIncreaseMultiplier", 1.0, "This is a global multiplier for the rate at which items heat up. Increase to make items heat up faster.");
 		TFCOptions.tempDecreaseMultiplier = (float) TFCOptions.getDoubleFor(config, "Time", "tempDecreaseMultiplier", 1.0, "This is a global multiplier for the rate at which items cool down. Increase to make items cool down faster.");
+		TFCOptions.enableWittyCalendar = TFCOptions.getBooleanFor(config, "Time", "enableWittyCalendar", true, "This will enable witty remarks on important calendar dates (like developers' birthdays).");
 
 		//Food Decay
 		Global.FOOD_DECAY_RATE = TFCOptions.getDoubleFor(config,"Food Decay","FoodDecayRate", 1.0170378966055869517978300569768, "This number causes base decay to equal 50% gain per day. If you wish to change, I recommend you look up a y-root calculator 1.0170378966055869517978300569768^24 = 1.5");


### PR DESCRIPTION
This could help some of the newer players.  When I first started and I saw the strange birth dates on the calendar I did not know what they meant.  This simple config option will allow users to disable those witty remarks in case they cause confusion.
