### PR TITLE
[0.79] Add the ability to drain water from a barrel directly into a water jug

### DIFF
--- a/src/Common/com/bioxx/tfc/Blocks/Devices/BlockBarrel.java
+++ b/src/Common/com/bioxx/tfc/Blocks/Devices/BlockBarrel.java
@@ -295,6 +295,11 @@ public class BlockBarrel extends BlockTerraContainer
 						player.inventory.setInventorySlotContents(player.inventory.currentItem, is);
 						return true;
 					}
+					else if ((equippedItem != null && equippedItem.getItem() == TFCItems.PotteryJug && equippedItem.getItemDamage() == 1)) {
+						ItemStack is = te.removeLiquid(equippedItem);
+						player.inventory.setInventorySlotContents(player.inventory.currentItem, is);
+						return true;
+					}
 				}
 
 				if(te.getInvCount() == 0)

--- a/src/Common/com/bioxx/tfc/TileEntities/TEBarrel.java
+++ b/src/Common/com/bioxx/tfc/TileEntities/TEBarrel.java
@@ -323,6 +323,17 @@ public class TEBarrel extends NetworkTileEntity implements IInventory
 				return out;
 			}
 		}
+		else if (fluid != null && fluid.amount >= FluidContainerRegistry.BUCKET_VOLUME / 2
+				&& fluid.getFluid() == TFCFluid.FRESHWATER && is.getItem() == TFCItems.PotteryJug
+				&& is.getItemDamage() == 1) {
+
+			fluid.amount -= FluidContainerRegistry.BUCKET_VOLUME / 2;
+			if (fluid.amount == 0) {
+				fluid = null;
+			}
+			worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+			return new ItemStack(TFCItems.PotteryJug, 1, 2);
+		}
 		return is;
 	}
 
@@ -372,9 +383,9 @@ public class TEBarrel extends NetworkTileEntity implements IInventory
 			}
 			else if(mode == MODE_OUT)
 			{
-				if(FluidContainerRegistry.isEmptyContainer(getInputStack()))
-				{
-					this.setInventorySlotContents(0, this.removeLiquid(getInputStack()));
+				ItemStack inputStack = getInputStack();
+				if (inputStack != null && (FluidContainerRegistry.isEmptyContainer(inputStack) || (inputStack.getItem() == TFCItems.PotteryJug && inputStack.getItemDamage() == 1))) {
+					this.setInventorySlotContents(0, this.removeLiquid(inputStack));
 				}
 			}
 		}


### PR DESCRIPTION
This will allow players to right click a barrel with a water jug or place the jug in the barrel fill slot to fill the water jug.

An important thing to note here is I did _not_ register the waterjug as a fluid container for one important reason:
Any item registered as a fluid container can be both filled and drained into the barrel, but now that we have finite water in 0.79, and water jugs can pick up water without removing source blocks it would be a very very cheap way to produce large quantities of water very fast.  I also figured that dumping your water jug into the shared water supply was unsanitary :)

So water jugs are half a bucket worth of water and can only pull water out of a barrel, not put water in.
