### PR TITLE
[0.79] Removing unnecessary tick handlers and simplifying others

### DIFF
--- a/src/Common/com/bioxx/tfc/Handlers/ServerTickHandler.java
+++ b/src/Common/com/bioxx/tfc/Handlers/ServerTickHandler.java
@@ -24,6 +24,7 @@ public class ServerTickHandler
 		}
 	}
 
+	/*
 	@SubscribeEvent
 	public void onServerPlayerTick(PlayerTickEvent event)
 	{
@@ -34,6 +35,7 @@ public class ServerTickHandler
 //			World world = player.worldObj;
 		}
 	}
+	*/
 
 
 

--- a/src/Common/com/bioxx/tfc/TerraFirmaCraft.java
+++ b/src/Common/com/bioxx/tfc/TerraFirmaCraft.java
@@ -42,7 +42,7 @@ import com.bioxx.tfc.Handlers.ChunkEventHandler;
 import com.bioxx.tfc.Handlers.CraftingHandler;
 import com.bioxx.tfc.Handlers.EnteringChunkHandler;
 import com.bioxx.tfc.Handlers.EntityDamageHandler;
-import com.bioxx.tfc.Handlers.EntityLivingHandler;
+import com.bioxx.tfc.Handlers.EntityPlayerHandler;
 import com.bioxx.tfc.Handlers.EntitySpawnHandler;
 import com.bioxx.tfc.Handlers.FoodCraftingHandler;
 import com.bioxx.tfc.Handlers.PlayerSkillEventHandler;
@@ -212,8 +212,10 @@ public class TerraFirmaCraft
 
 		MinecraftForge.EVENT_BUS.register(new PlayerSkillEventHandler());
 
-		// Register the Entity Living Update Handler
-		MinecraftForge.EVENT_BUS.register(new EntityLivingHandler());
+		// Register the Player Update Handler (on two message busses)
+		EntityPlayerHandler playerHandler = new EntityPlayerHandler();
+		MinecraftForge.EVENT_BUS.register(playerHandler);
+		FMLCommonHandler.instance().bus().register(playerHandler);
 
 		// Register all the render stuff for the client
 		proxy.registerRenderInformation();


### PR DESCRIPTION
There are a couple of tick handlers that are covering more ground than they need to.  This will lead to some unneeded calculations every tick that can be eliminated.  This is a small optimization, nothing more - its that little piece of me that craves high performance computing by removing wasted cpu cycles.

1 There was an empty ServerTickEvent handler listening for the player tick event, is has been removed.
2 The EntityLivingHandler was processing the EntityLivingUpdate for every loaded entity and each time it was asking "instanceof Player".  Instead, I changed the handler to listen for PlayerTickEvent (and renamed the class accordingly) which is the player specific version of EntityLivingUpdate.  This will cause the listener to fire twice per tick per player (pre and post - post is ignored) instead of once per loaded entity.  A weird side-effect is we have to register this listener on two message busses.

I have played with this for some time, and it ticked properly in all my play-testing.

You can see the difference between the two events by looking at
EntityPlayer:274 - the player's tick event
EntityLivingBase:1774 - every other entity's tick event (also fired by the player on EntityPlayer:342)
