### PR TITLE
[0.79] Improve localization support (take 2)

### DIFF
--- a/src/Common/com/bioxx/tfc/Blocks/Vanilla/BlockBed.java
+++ b/src/Common/com/bioxx/tfc/Blocks/Vanilla/BlockBed.java
@@ -97,7 +97,7 @@ public class BlockBed extends BlockDirectional
 
 					if (entityplayer1 != null)
 					{
-						par5EntityPlayer.addChatMessage(new ChatComponentText("tile.bed.occupied.name"));
+						par5EntityPlayer.addChatMessage(new ChatComponentText(StatCollector.translateToLocal("tile.bed.occupied")));
 						return true;
 					}
 
@@ -115,9 +115,9 @@ public class BlockBed extends BlockDirectional
 				else
 				{
 					if (enumstatus == EnumStatus.NOT_POSSIBLE_NOW)
-						par5EntityPlayer.addChatMessage(new ChatComponentText("tile.bed.noSleep.name"));
+						par5EntityPlayer.addChatMessage(new ChatComponentText(StatCollector.translateToLocal("tile.bed.noSleep")));
 					else if (enumstatus == EnumStatus.NOT_SAFE)
-						par5EntityPlayer.addChatMessage(new ChatComponentText("tile.bed.notSafe.name"));
+						par5EntityPlayer.addChatMessage(new ChatComponentText(StatCollector.translateToLocal("tile.bed.notSafe")));
 
 					return true;
 				}

--- a/src/Common/com/bioxx/tfc/Commands/CommandTime.java
+++ b/src/Common/com/bioxx/tfc/Commands/CommandTime.java
@@ -4,12 +4,14 @@ import java.util.List;
 
 import com.bioxx.tfc.Core.TFC_Time;
 import com.bioxx.tfc.api.TFCOptions;
+import java.util.regex.Pattern;
 
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.command.WrongUsageException;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.StatCollector;
 import net.minecraft.world.WorldServer;
 
 public class CommandTime extends CommandBase
@@ -56,7 +58,8 @@ public class CommandTime extends CommandBase
 					}
 					if(i < currentTime)
 					{
-						par1ICommandSender.addChatMessage(new ChatComponentText("Cannot set time to before current time."));
+						String message = StatCollector.translateToLocal("commands.time.invalid").replaceAll(Pattern.quote("$CURRTIME"), String.valueOf(currentTime));
+						par1ICommandSender.addChatMessage(new ChatComponentText(message));
 					}
 					else
 					{
@@ -71,7 +74,8 @@ public class CommandTime extends CommandBase
 					i = parseIntWithMin(par1ICommandSender, par2ArrayOfStr[1], 0);
 					if(i+ currentTime < currentTime)
 					{
-						par1ICommandSender.addChatMessage(new ChatComponentText("Cannot set time to before current time."));
+						String message = StatCollector.translateToLocal("commands.time.invalid").replaceAll(Pattern.quote("$CURRTIME"), String.valueOf(currentTime));
+						par1ICommandSender.addChatMessage(new ChatComponentText(message));
 					}
 					else
 					{

--- a/src/Common/com/bioxx/tfc/Core/Player/BodyTempStats.java
+++ b/src/Common/com/bioxx/tfc/Core/Player/BodyTempStats.java
@@ -187,25 +187,30 @@ public class BodyTempStats
 
 	private void tellPlayerMessage(EntityPlayer player)
 	{
-		/*		switch(temperatureLevel/10)
+		/*
+		String status = "";
+		switch(temperatureLevel/10)
 		{
-		case -1:
-		case 0:
-		case 1: player.addChatMessage(new ChatComponentText("You feel comfortable"));break;
-		case -2: player.addChatMessage(new ChatComponentText("You feel cool."));break;
-		case -3: player.addChatMessage(new ChatComponentText("You feel chilled."));break;
-		case -4: player.addChatMessage(new ChatComponentText("You feel cold."));break;
-		case -5: player.addChatMessage(new ChatComponentText("You feel numb."));break;
-		case -6: player.addChatMessage(new ChatComponentText("You feel freezing!"));break;
-		case -7: killPlayer(player);break;
-		case 2: player.addChatMessage(new ChatComponentText("You feel warm."));break;
-		case 3: player.addChatMessage(new ChatComponentText("You feel very warm."));break;
-		case 4: player.addChatMessage(new ChatComponentText("You feel hot."));break;
-		case 5: player.addChatMessage(new ChatComponentText("You feel very hot."));break;
-		case 6: player.addChatMessage(new ChatComponentText("You feel extremely hot!"));break;
-		case 7: killPlayer(player);break;
+			case -7: killPlayer(player); break;
+			case -6: status = "status.player.freezing"; break;
+			case -5: status = "status.player.numb"; break;
+			case -4: status = "status.player.cold"; break;
+			case -3: status = "status.player.chilled"; break;
+			case -2: status = "status.player.cold"; break;
+			case -1:
+			case 0:
+			case 1: status = "status.player.comfortable"; break;
+			case 2: status = "status.player.warm"; break;
+			case 3: status = "status.player.verywarm"; break;
+			case 4: status = "status.player.hot"; break;
+			case 5: status = "status.player.veryhot"; break;
+			case 6: status = "status.player.extremelyhot"; break;
+			case 7: killPlayer(player);break;
 		}
-		 */
+		if (status != "") {
+			player.addChatMessage(new ChatComponentText(StatCollector.translateToLocal(status)));
+		}
+		*/
 	}
 
 	private void killPlayer(EntityPlayer player)

--- a/src/Common/com/bioxx/tfc/Entities/Mobs/EntityBear.java
+++ b/src/Common/com/bioxx/tfc/Entities/Mobs/EntityBear.java
@@ -25,6 +25,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.DamageSource;
+import net.minecraft.util.StatCollector;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 
@@ -584,10 +585,10 @@ public class EntityBear extends EntityTameable implements ICausesDamage, IAnimal
 	{
 		if(!worldObj.isRemote)
 		{
-			par1EntityPlayer.addChatMessage(new ChatComponentText(getGender()==GenderEnum.FEMALE?"Female":"Male"));
+			par1EntityPlayer.addChatMessage(new ChatComponentText(StatCollector.translateToLocal(getGender() == GenderEnum.FEMALE ? "entity.animal.female" : "entity.animal.male")));
 			if(getGender()==GenderEnum.FEMALE && pregnant)
 			{
-				par1EntityPlayer.addChatMessage(new ChatComponentText("Pregnant"));
+				par1EntityPlayer.addChatMessage(new ChatComponentText(StatCollector.translateToLocal("entity.animal.pregnant")));
 			}
 			//par1EntityPlayer.addChatMessage("12: "+dataWatcher.getWatchableObjectInt(12)+", 15: "+dataWatcher.getWatchableObjectInt(15));
 		}

--- a/src/Common/com/bioxx/tfc/Entities/Mobs/EntityChickenTFC.java
+++ b/src/Common/com/bioxx/tfc/Entities/Mobs/EntityChickenTFC.java
@@ -480,7 +480,7 @@ public class EntityChickenTFC extends EntityChicken implements IAnimal
 		{
 			/*if(!player.isSneaking())
 			{
-				player.addChatMessage(new ChatComponentText(getGender()==GenderEnum.FEMALE?"Female":"Male"));
+				player.addChatMessage(new ChatComponentText(StatCollector.translateToLocal(getGender() == GenderEnum.FEMALE ? "entity.animal.female" : "entity.animal.male")));
 			}*/
 		}
 		//player.addChatMessage("12: "+dataWatcher.getWatchableObjectInt(12)+", 15: "+dataWatcher.getWatchableObjectInt(15));

--- a/src/Common/com/bioxx/tfc/Entities/Mobs/EntityCowTFC.java
+++ b/src/Common/com/bioxx/tfc/Entities/Mobs/EntityCowTFC.java
@@ -16,6 +16,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.StatCollector;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 
@@ -306,10 +307,10 @@ public class EntityCowTFC extends EntityCow implements IAnimal
 	{
 		if(!worldObj.isRemote)
 		{
-			//player.addChatMessage(new ChatComponentText(getGender()==GenderEnum.FEMALE ? "Female" : "Male"));
+			//player.addChatMessage(new ChatComponentText(StatCollector.translateToLocal(getGender() == GenderEnum.FEMALE ? "entity.animal.female" : "entity.animal.male")));
 			if(getGender()==GenderEnum.FEMALE && pregnant)
 			{
-				player.addChatMessage(new ChatComponentText("Pregnant"));
+				player.addChatMessage(new ChatComponentText(StatCollector.translateToLocal("entity.animal.pregnant")));
 			}
 			//player.addChatMessage("12: "+dataWatcher.getWatchableObjectInt(12)+", 15: "+dataWatcher.getWatchableObjectInt(15));
 

--- a/src/Common/com/bioxx/tfc/Entities/Mobs/EntityDeer.java
+++ b/src/Common/com/bioxx/tfc/Entities/Mobs/EntityDeer.java
@@ -22,6 +22,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.DamageSource;
+import net.minecraft.util.StatCollector;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 
@@ -306,10 +307,10 @@ public class EntityDeer extends EntityAnimal implements IAnimal
 	{
 		if(!worldObj.isRemote)
 		{
-			//par1EntityPlayer.addChatMessage(new ChatComponentText(getGender()==GenderEnum.FEMALE?"Female":"Male"));
+			//par1EntityPlayer.addChatMessage(new ChatComponentText(StatCollector.translateToLocal(getGender() == GenderEnum.FEMALE ? "entity.animal.female" : "entity.animal.male")));
 			if(getGender()==GenderEnum.FEMALE && pregnant)
 			{
-				par1EntityPlayer.addChatMessage(new ChatComponentText("Pregnant"));
+				par1EntityPlayer.addChatMessage(new ChatComponentText(StatCollector.translateToLocal("entity.animal.pregnant")));
 			}
 			//par1EntityPlayer.addChatMessage("12: "+dataWatcher.getWatchableObjectInt(12)+", 15: "+dataWatcher.getWatchableObjectInt(15));
 		}

--- a/src/Common/com/bioxx/tfc/Entities/Mobs/EntityHorseTFC.java
+++ b/src/Common/com/bioxx/tfc/Entities/Mobs/EntityHorseTFC.java
@@ -32,6 +32,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.StatCollector;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 
@@ -331,9 +332,9 @@ public class EntityHorseTFC extends EntityHorse implements IInvBasic, IAnimal
 		ItemStack itemstack = player.inventory.getCurrentItem();
 		if(!worldObj.isRemote)
 		{
-			player.addChatMessage(new ChatComponentText(getGender() == GenderEnum.FEMALE ? "Female" : "Male"));
+			player.addChatMessage(new ChatComponentText(StatCollector.translateToLocal(getGender() == GenderEnum.FEMALE ? "entity.animal.female" : "entity.animal.male")));
 			if(getGender()==GenderEnum.FEMALE && pregnant)
-				player.addChatMessage(new ChatComponentText("Pregnant"));
+				player.addChatMessage(new ChatComponentText(StatCollector.translateToLocal("entity.animal.pregnant")));
 			//player.addChatMessage("12: " + dataWatcher.getWatchableObjectInt(12) + ", 15: " + dataWatcher.getWatchableObjectInt(15));
 		}
 

--- a/src/Common/com/bioxx/tfc/Entities/Mobs/EntityPigTFC.java
+++ b/src/Common/com/bioxx/tfc/Entities/Mobs/EntityPigTFC.java
@@ -25,6 +25,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.stats.AchievementList;
 import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.StatCollector;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 
@@ -276,9 +277,9 @@ public class EntityPigTFC extends EntityPig implements IAnimal
 	{
 		if(!worldObj.isRemote)
 		{
-			//player.addChatMessage(new ChatComponentText(getGender() == GenderEnum.FEMALE ? "Female" : "Male"));
+			//player.addChatMessage(new ChatComponentText(StatCollector.translateToLocal(getGender() == GenderEnum.FEMALE ? "entity.animal.female" : "entity.animal.male")));
 			if(getGender() == GenderEnum.FEMALE && pregnant)
-				player.addChatMessage(new ChatComponentText("Pregnant"));
+				player.addChatMessage(new ChatComponentText(StatCollector.translateToLocal("entity.animal.pregnant")));
 			//par1EntityPlayer.addChatMessage("12: "+dataWatcher.getWatchableObjectInt(12)+", 15: "+dataWatcher.getWatchableObjectInt(15));
 		}
 		ItemStack itemstack = player.inventory.getCurrentItem();

--- a/src/Common/com/bioxx/tfc/Entities/Mobs/EntitySheepTFC.java
+++ b/src/Common/com/bioxx/tfc/Entities/Mobs/EntitySheepTFC.java
@@ -15,6 +15,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.StatCollector;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
@@ -313,9 +314,9 @@ public class EntitySheepTFC extends EntitySheep implements IShearable, IAnimal
 	{
 		if(!worldObj.isRemote)
 		{
-			//player.addChatMessage(new ChatComponentText(getGender() == GenderEnum.FEMALE ? "Female" : "Male"));
+			//player.addChatMessage(new ChatComponentText(StatCollector.translateToLocal(getGender() == GenderEnum.FEMALE ? "entity.animal.female" : "entity.animal.male")));
 			if(getGender() == GenderEnum.FEMALE && pregnant)
-				player.addChatMessage(new ChatComponentText("Pregnant"));
+				player.addChatMessage(new ChatComponentText(StatCollector.translateToLocal("entity.animal.pregnant")));
 
 			if(player.getHeldItem() != null && player.getHeldItem().getItem() instanceof ItemCustomKnife && !getSheared() && getPercentGrown(this) > 0.95F)
 			{

--- a/src/Common/com/bioxx/tfc/Entities/Mobs/EntityWolfTFC.java
+++ b/src/Common/com/bioxx/tfc/Entities/Mobs/EntityWolfTFC.java
@@ -16,6 +16,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.DamageSource;
+import net.minecraft.util.StatCollector;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 
@@ -483,9 +484,9 @@ public class EntityWolfTFC extends EntityWolf implements IAnimal, IInnateArmor
 				}
 			}
 
-			player.addChatMessage(new ChatComponentText(getGender() == GenderEnum.FEMALE ? "Female" : "Male"));
+			player.addChatMessage(new ChatComponentText(StatCollector.translateToLocal(getGender() == GenderEnum.FEMALE ? "entity.animal.female" : "entity.animal.male")));
 			if(getGender() == GenderEnum.FEMALE && pregnant)
-				player.addChatMessage(new ChatComponentText("Pregnant"));
+				player.addChatMessage(new ChatComponentText(StatCollector.translateToLocal("entity.animal.pregnant")));
 
 			//par1EntityPlayer.addChatMessage("12: "+dataWatcher.getWatchableObjectInt(12)+", 15: "+dataWatcher.getWatchableObjectInt(15));
 		}

--- a/src/Common/com/bioxx/tfc/Items/Tools/ItemProPick.java
+++ b/src/Common/com/bioxx/tfc/Items/Tools/ItemProPick.java
@@ -2,6 +2,7 @@ package com.bioxx.tfc.Items.Tools;
 
 import java.util.HashMap;
 import java.util.Random;
+import java.util.regex.Pattern;
 
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.texture.IIconRegister;
@@ -146,7 +147,8 @@ public class ItemProPick extends ItemTerra
 	 */
 	private void TellResult(EntityPlayer player, ItemStack ore)
 	{
-		player.addChatMessage(new ChatComponentText(String.format("%s %s", StatCollector.translateToLocal("gui.ProPick.Found"), ore.getItem().getItemStackDisplayName(ore))));
+		String message = StatCollector.translateToLocal("gui.ProPick.Found").replaceAll(Pattern.quote("$ORE"), ore.getItem().getItemStackDisplayName(ore));
+		player.addChatMessage(new ChatComponentText(message));
 	}
 
 	/*
@@ -164,16 +166,19 @@ public class ItemProPick extends ItemTerra
 		ProspectResult result = results.values().toArray(new ProspectResult[0])[index];
 		String oreName = result.ItemStack.getItem().getItemStackDisplayName(result.ItemStack);
 
+		String message = "";
 		if (result.Count < 10)
-			player.addChatMessage(new ChatComponentText(String.format("%s %s", StatCollector.translateToLocal("gui.ProPick.FoundTraces"), oreName)));
+			message = StatCollector.translateToLocal("gui.ProPick.FoundTraces").replaceAll(Pattern.quote("$ORE"), oreName);
 		else if(result.Count < 20)
-			player.addChatMessage(new ChatComponentText(String.format("%s %s", StatCollector.translateToLocal("gui.ProPick.FoundSmall"), oreName)));
+			message = StatCollector.translateToLocal("gui.ProPick.FoundSmall").replaceAll(Pattern.quote("$ORE"), oreName);
 		else if (result.Count < 40)
-			player.addChatMessage(new ChatComponentText(String.format("%s %s", StatCollector.translateToLocal("gui.ProPick.FoundMedium"), oreName)));
+			message = StatCollector.translateToLocal("gui.ProPick.FoundMedium").replaceAll(Pattern.quote("$ORE"), oreName);
 		else if (result.Count < 80)
-			player.addChatMessage(new ChatComponentText(String.format("%s %s", StatCollector.translateToLocal("gui.ProPick.FoundLarge"), oreName)));
+			message = StatCollector.translateToLocal("gui.ProPick.FoundLarge").replaceAll(Pattern.quote("$ORE"), oreName);
 		else
-			player.addChatMessage(new ChatComponentText(String.format("%s %s", StatCollector.translateToLocal("gui.ProPick.FoundVeryLarge"), oreName)));
+			message = StatCollector.translateToLocal("gui.ProPick.FoundVeryLarge").replaceAll(Pattern.quote("$ORE"), oreName);
+
+		player.addChatMessage(new ChatComponentText(message));
 
 		oreName = null;
 		result = null;

--- a/src/Resources/assets/terrafirmacraft/lang/en_US.lang
+++ b/src/Resources/assets/terrafirmacraft/lang/en_US.lang
@@ -2257,12 +2257,12 @@ gui.GoldPan.UseEmpty=Must use on sand in or near a river. Or gravel from under a
 gui.GoldPan.UseFull=Must use under flowing water.
 gui.goldpan.overused=This area seems to be overworked. You probably wouldn't find much.
 
-gui.ProPick.Found=Found
-gui.ProPick.FoundTraces=Found traces of
-gui.ProPick.FoundSmall=Found a small sample of
-gui.ProPick.FoundMedium=Found a medium sample of
-gui.ProPick.FoundLarge=Found a large sample of
-gui.ProPick.FoundVeryLarge=Found a very large sample of
+gui.ProPick.Found=Found $ORE.
+gui.ProPick.FoundTraces=Found traces of $ORE.
+gui.ProPick.FoundSmall=Found a small sample of $ORE.
+gui.ProPick.FoundMedium=Found a medium sample of $ORE.
+gui.ProPick.FoundLarge=Found a large sample of $ORE.
+gui.ProPick.FoundVeryLarge=Found a very large sample of $ORE.
 gui.ProPick.FoundNothing=Found nothing of interest.
 
 #== Creative Tabs ==
@@ -2364,3 +2364,21 @@ gui.skillpage=Skills
 tile.MetalTrapDoor.name=Trap Door
 item.Mud Brick.name=Mud Brick
 item.Wet Mud Brick.name=Wet Mud Brick
+
+entity.animal.male=Male
+entity.animal.female=Female
+entity.animal.pregnant=Pregnant
+
+status.player.comfortable=You feel comfortable.
+status.player.cool=You feel cool.
+status.player.chilled=You feel chilled.
+status.player.cold=You feel cold.
+status.player.numb=You feel numb.
+status.player.freezing=You feel freezing!
+status.player.warm=You feel warm.
+status.player.verywarm=You feel very warm.
+status.player.hot=You feel hot.
+status.player.veryhot=You feel very hot.
+status.player.extremelyhot=You feel extremely hot!
+
+commands.time.invalid=Cannot set time to before current time ($CURRTIME).


### PR DESCRIPTION
[Updated from #577]

There were a couple of broken localization strings for beds (tile.bed.nosleep.name, and tile.bed.notsafe.name). I fixed them (removed the .name) and decided to fully implement localization support for all ChatMessages. Most of these messages end up being exactly the same only passed through localization, there are only a couple of cases where the localization had to change.

Most notably the ProPick was always formatted as
translate(Found message)+translate(orename) which is not translatable.
I changed the localization strings to use macros that are converted to the orename at runtime:
translate(Found message with macro).replace(macro, orename)
so the specific .lang file can place the macro ($ORE for the propick) wherever in the message is required.

Debug messages are not included in this PR as per request.

CommandTime is included, and it supports a macro $CURRTIME - if you put this macro in your translation line it will be replaced with the current world time in chat.  You can safely ignore this macro in your translation if you choose.
