### PR TITLE
Allow loose sticks to spawn on sand and gravel

### DIFF
--- a/src/Common/com/bioxx/tfc/WorldGen/Generators/WorldGenLooseRocks.java
+++ b/src/Common/com/bioxx/tfc/WorldGen/Generators/WorldGenLooseRocks.java
@@ -117,7 +117,7 @@ public class WorldGenLooseRocks implements IWorldGenerator
 				world.getBlock(i, j, k) .getMaterial() == Material.sand || world.getBlock(i, j, k).getMaterial() == Material.ground) && world.getBlock(i, j, k).isOpaqueCube())
 		{
 			TFCBiome biome = (TFCBiome) world.getBiomeGenForCoords(i, k);
-			if((biome == TFCBiome.beach || biome == TFCBiome.ocean || biome == TFCBiome.river || isNearTree(world, i, j, k)) && 
+			if((biome == TFCBiome.beach || biome == TFCBiome.gravelbeach || biome == TFCBiome.ocean || biome == TFCBiome.river || isNearTree(world, i, j, k)) && 
 					world.setBlock(i, j + 1, k, TFCBlocks.worldItem, 0, 2))
 			{
 				TEWorldItem te =(TEWorldItem) world.getTileEntity(i, j + 1, k);


### PR DESCRIPTION
After the recent beach update, some (or all) coastal areas are now either sand or gravel.  This means loose sticks can't spawn on beaches anymore.  This update changes the sticks spawn rules so they can appear on sand and gravel.

And as a side-effect, they can also spawn on peat and dirt (without grass).  They can also spawn on farmland and charcoal but since those blocks are not worldgen those cases will never occur.
