### PR TITLE
Add Ore dictionary matching for basic barrel recipes

### DIFF
--- a/src/API/com/bioxx/tfc/api/Crafting/BarrelRecipe.java
+++ b/src/API/com/bioxx/tfc/api/Crafting/BarrelRecipe.java
@@ -2,6 +2,7 @@ package com.bioxx.tfc.api.Crafting;
 
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.oredict.OreDictionary;
 
 public class BarrelRecipe
 {
@@ -52,8 +53,9 @@ public class BarrelRecipe
 		boolean fStack = !removesLiquid ? true : (barrelFluid != null && item != null && fluid != null && outFluid != null && fluid.amount >= item.stackSize*outFluid.amount);
 
 		boolean anyStack = !removesLiquid && !isSealedRecipe && this.outItemStack == null;
+		boolean itemsEqual = OreDictionary.itemMatches(inItemStack, item, false);
 
-		return ((inItemStack != null && inItemStack.isItemEqual(item) && (iStack || anyStack)) || inItemStack == null) && 
+		return ((inItemStack != null && itemsEqual && (iStack || anyStack)) || inItemStack == null) &&
 				((barrelFluid != null && barrelFluid.isFluidEqual(fluid) && (fStack || anyStack)) || barrelFluid == null);
 	}
 


### PR DESCRIPTION
Allow barrels to perform ore dictionary matching for basic item->item recipes.  Since I only modified BarrelRecipe.java only recipes that convert item->item should be affected.
