### PR TITLE
Set materials for flowers and world debris so snow cannot form on top of them

### DIFF
--- a/src/Common/com/bioxx/tfc/Blocks/BlockWorldItem.java
+++ b/src/Common/com/bioxx/tfc/Blocks/BlockWorldItem.java
@@ -22,7 +22,7 @@ public class BlockWorldItem extends BlockTerraContainer
 {
 	public BlockWorldItem()
 	{
-		super(Material.wood);
+		super(Material.circuits);
 		this.setBlockBounds(0F, 0.00F, 0F, 1F, 0.05F, 1F);
 	}
 

--- a/src/Common/com/bioxx/tfc/Blocks/Flora/BlockFlower.java
+++ b/src/Common/com/bioxx/tfc/Blocks/Flora/BlockFlower.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Random;
 
 import net.minecraft.block.Block;
+import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
@@ -28,6 +29,7 @@ public class BlockFlower extends BlockTerra
 
 	public BlockFlower()
 	{
+		super(Material.plants);
 		this.setTickRandomly(true);
 		float var4 = 0.2F;
 		this.setBlockBounds(0.5F - var4, 0.0F, 0.5F - var4, 0.5F + var4, var4 * 3.0F, 0.5F + var4);

--- a/src/Common/com/bioxx/tfc/Blocks/Flora/BlockFlower2.java
+++ b/src/Common/com/bioxx/tfc/Blocks/Flora/BlockFlower2.java
@@ -1,11 +1,10 @@
 package com.bioxx.tfc.Blocks.Flora;
 
-
 public class BlockFlower2 extends BlockFlower
 {
-	private static final String[] flowerNames = new String[]{"flower_rose", "flower_blue_orchid", "flower_allium", "flower_houstonia", "flower_tulip_red", "flower_tulip_orange", "flower_tulip_white", "flower_tulip_pink", "flower_oxeye_daisy"};
-
 	public BlockFlower2()
 	{
+		super();
+		flowerNames = new String[]{"flower_rose", "flower_blue_orchid", "flower_allium", "flower_houstonia", "flower_tulip_red", "flower_tulip_orange", "flower_tulip_white", "flower_tulip_pink", "flower_oxeye_daisy"};
 	}
 }


### PR DESCRIPTION
The materials for some basic blocks were set strangely:
- Flowers (BlockFlower and BlockFlower2) were using the default material (stone).
- Debris (BlockWorldItem) was using the wood material.

I changed the debris items to use Material.circuits (like torches) and changed the flowers to use Material.plants.  This will prevent snow layers from forming on top of them.
