### PR TITLE
Fixed a double chest bounding box error

### DIFF
--- a/src/Common/com/bioxx/tfc/Blocks/Devices/BlockChestTFC.java
+++ b/src/Common/com/bioxx/tfc/Blocks/Devices/BlockChestTFC.java
@@ -192,6 +192,7 @@ public class BlockChestTFC extends BlockTerraContainer
 					break;
 				case WEST:
 					this.setBlockBounds(0.0F, 0.0F, 0.0625F, 0.9375F, 0.875F, 0.9375F);
+					break;
 				default:
 				case UNKNOWN:
 					this.setBlockBounds(0.0625F, 0.0F, 0.0625F, 0.9375F, 0.875F, 0.9375F);


### PR DESCRIPTION
Fixes a missing break statement that was causing a small gap in the middle of east-west aligned double chests.
