### PR TITLE
Add config option to allow users to control the effectiveness of salting

### DIFF
--- a/src/API/com/bioxx/tfc/api/TFCOptions.java
+++ b/src/API/com/bioxx/tfc/api/TFCOptions.java
@@ -49,6 +49,7 @@ public class TFCOptions
 	public static boolean useDecayProtection = true;
 	public static int decayProtectionDays = 18;
 	public static float decayMultiplier = 1.0f;
+	public static float saltDecayScale = 0.5f;
 	public static int simSpeedNoPlayers = 1000;
 
 	public static int smallOreUnits = 10;

--- a/src/Common/com/bioxx/tfc/Food/ItemFoodTFC.java
+++ b/src/Common/com/bioxx/tfc/Food/ItemFoodTFC.java
@@ -149,7 +149,7 @@ public class ItemFoodTFC extends ItemTerra implements ISize, ICookableFood
 		if(is.getTagCompound().hasKey("Pickled"))
 			mult *= 0.8f;
 		if(is.getTagCompound().hasKey("isSalted"))
-			mult *= 0.5f;
+			mult *= TFCOptions.saltDecayScale;
 		return decayRate * (TFC_Time.getYearRatio(96)) * mult;
 	}
 

--- a/src/Common/com/bioxx/tfc/TerraFirmaCraft.java
+++ b/src/Common/com/bioxx/tfc/TerraFirmaCraft.java
@@ -306,6 +306,7 @@ public class TerraFirmaCraft
 		TFCOptions.useDecayProtection = TFCOptions.getBooleanFor(config, "Food Decay", "useDecayProtection", true,"Set this to false if you want food to auto decay when a chunk is loaded instead of limiting decay when a chunk has been unloaded for a long period.");
 		TFCOptions.decayProtectionDays = TFCOptions.getIntFor(config,"Food Decay","decayProtectionDays",24, "If a food item has not been ticked for >= this number of days than when it is ticked for the first time, only a small amount of decay will occur.");
 		TFCOptions.decayMultiplier = (float)TFCOptions.getDoubleFor(config,"Food Decay","FoodDecayMultiplier", 1.0, "This is a global multiplier for food decay. Unlike FoodDecayRate which only modifies the base decay and not the environmental effect upon decay, this multiplier will multiply against the entire amount. Set to 0 to turn decay off.");
+		TFCOptions.saltDecayScale = (float)TFCOptions.getDoubleFor(config, "Food Decay", "SaltDecayScaling", 0.5f, "This is a multiplier on food decay rate when salted. Salting food will reduce the food decay to this percent of normal decay (default 0.5 = 50%).");
 
 		//Cavein Options
 		TFCOptions.minimumRockLoad = TFCOptions.getIntFor(config,"Cavein Options","minimumRockLoad",1, "This is the minimum number of solid blocks that must be over a section in order for it to collapse.");


### PR DESCRIPTION
Add a simple config option so users can control how effective salt is at preserving food.  Perhaps some boundary checks could be added so people don't go outside of 0 < amnt < 1?
