### PR TITLE
add manifest to deobfJar and add some gitignore for intellij

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,10 @@ screenshots/
 .project
 .classpath
 options.txt
+out
+*.iws
+*.ipr
+*.iml
+mods
+asm
 

--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,12 @@ sourceSets {
 task deobfJar(type: Jar) {
     from sourceSets.main.output
     appendix = 'deobf'
+	
+	manifest.attributes(
+            'FMLCorePlugin': 'com.bioxx.tfc.TFCASMLoadingPlugin',
+			'FMLCorePluginContainsFMLMod': 'true',
+			'FMLAT': 'tfc_at.cfg'
+    )
 }
  //creates a jar containing only the src
 task sourceJar(type: Jar) {
@@ -94,4 +100,4 @@ jar {
 			'FMLCorePluginContainsFMLMod': 'true',
 			'FMLAT': 'tfc_at.cfg'
     )
-	}
+}


### PR DESCRIPTION
Adding the manifest to deobfJar is required to make FTC run without a dummy jar in the mods folder.

I'm working on NEI <> TFC integration so I would very much appreciate this!
(I might create some more small PRs to avoid having to use reflection later on)

Also, is there any way to convince you guys to use a CI system and maven repo so I can automatically build against the latest TFC build?
I would understand if you don't want to do any setup yourself. I can do it for you or just make an account on my server.

Thanks for reading,
Dries007
