### PR TITLE
[0.79.7] Missing hour23

### DIFF
--- a/src/Common/com/bioxx/tfc/Core/TFC_Time.java
+++ b/src/Common/com/bioxx/tfc/Core/TFC_Time.java
@@ -258,7 +258,7 @@ public class TFC_Time
 // TODO do we need this? same as getHour(), never used
 	public static int getHourOfDayFromTotalHours()
 	{
-		return getHourOfDayFromTotalHours((int)getTotalHours());
+		return  getHourOfDayFromTotalHours((int)getTotalHours());
 	}
 
 	public static int getHourOfDayFromTotalHours(int th)


### PR DESCRIPTION
Proposed correction for:
http://terrafirmacraft.com/f/topic/6957-0797-missing-hour-23-hour-6-double-long/#entry93820

Short details:
there is no 23:00, 6:00 is doubled
The hour calculation is adding 23 when calculated hour is negative, but a day is 24...+
