### PR TITLE
Fix Shift Click Ghosts

### DIFF
--- a/src/Common/com/bioxx/tfc/Containers/ContainerAnvil.java
+++ b/src/Common/com/bioxx/tfc/Containers/ContainerAnvil.java
@@ -63,7 +63,7 @@ public class ContainerAnvil extends ContainerTFC
 	}
 
 	@Override
-	public ItemStack transferStackInSlot(EntityPlayer entityplayer, int i)
+	public ItemStack transferStackInSlotTFC(EntityPlayer entityplayer, int i)
 	{
 		ItemStack origStack = null;
 		Slot slot = (Slot)inventorySlots.get(i);

--- a/src/Common/com/bioxx/tfc/Containers/ContainerBarrel.java
+++ b/src/Common/com/bioxx/tfc/Containers/ContainerBarrel.java
@@ -78,7 +78,7 @@ public class ContainerBarrel extends ContainerTFC
 	}
 
 	@Override
-	public ItemStack transferStackInSlot(EntityPlayer entityplayer, int i)
+	public ItemStack transferStackInSlotTFC(EntityPlayer entityplayer, int i)
 	{
 		Slot slot = (Slot)inventorySlots.get(i);
 		if(slot != null && slot.getHasStack())

--- a/src/Common/com/bioxx/tfc/Containers/ContainerBlastFurnace.java
+++ b/src/Common/com/bioxx/tfc/Containers/ContainerBlastFurnace.java
@@ -40,7 +40,7 @@ public class ContainerBlastFurnace extends ContainerTFC
 	}
 
 	@Override
-	public ItemStack transferStackInSlot(EntityPlayer entityplayer, int i)
+	public ItemStack transferStackInSlotTFC(EntityPlayer entityplayer, int i)
 	{
 		Slot slot = (Slot)inventorySlots.get(i);
 		Slot slot1 = (Slot)inventorySlots.get(0);

--- a/src/Common/com/bioxx/tfc/Containers/ContainerChestTFC.java
+++ b/src/Common/com/bioxx/tfc/Containers/ContainerChestTFC.java
@@ -98,7 +98,7 @@ public class ContainerChestTFC extends ContainerTFC
 	 * Called to transfer a stack from one inventory to the other eg. when shift clicking.
 	 */
 	@Override
-	public ItemStack transferStackInSlot(EntityPlayer player, int slotNum)
+	public ItemStack transferStackInSlotTFC(EntityPlayer player, int slotNum)
 	{
 		ItemStack var2 = null;
 		Slot slot = (Slot)this.inventorySlots.get(slotNum);

--- a/src/Common/com/bioxx/tfc/Containers/ContainerCrucible.java
+++ b/src/Common/com/bioxx/tfc/Containers/ContainerCrucible.java
@@ -39,7 +39,7 @@ public class ContainerCrucible extends ContainerTFC
 	}
 
 	@Override
-	public ItemStack transferStackInSlot(EntityPlayer player, int clickedIndex)
+	public ItemStack transferStackInSlotTFC(EntityPlayer player, int clickedIndex)
 	{
 		ItemStack returnedStack = null;
 		Slot clickedSlot = (Slot)this.inventorySlots.get(clickedIndex);

--- a/src/Common/com/bioxx/tfc/Containers/ContainerFirepit.java
+++ b/src/Common/com/bioxx/tfc/Containers/ContainerFirepit.java
@@ -58,7 +58,7 @@ public class ContainerFirepit extends ContainerTFC
 	}
 
 	@Override
-	public ItemStack transferStackInSlot(EntityPlayer p, int i)
+	public ItemStack transferStackInSlotTFC(EntityPlayer p, int i)
 	{
 		Slot slot = (Slot)inventorySlots.get(i);
 		Slot slotinput = (Slot)inventorySlots.get(0);

--- a/src/Common/com/bioxx/tfc/Containers/ContainerFoodPrep.java
+++ b/src/Common/com/bioxx/tfc/Containers/ContainerFoodPrep.java
@@ -94,7 +94,7 @@ public class ContainerFoodPrep extends ContainerTFC
 	}
 
 	@Override
-	public ItemStack transferStackInSlot(EntityPlayer player, int clickedIndex)
+	public ItemStack transferStackInSlotTFC(EntityPlayer player, int clickedIndex)
 	{
 		ItemStack returnedStack = null;
 		Slot clickedSlot = (Slot)this.inventorySlots.get(clickedIndex);

--- a/src/Common/com/bioxx/tfc/Containers/ContainerForge.java
+++ b/src/Common/com/bioxx/tfc/Containers/ContainerForge.java
@@ -58,7 +58,7 @@ public class ContainerForge extends ContainerTFC
 	}
 
 	@Override
-	public ItemStack transferStackInSlot(EntityPlayer entityplayer, int slotNum)
+	public ItemStack transferStackInSlotTFC(EntityPlayer entityplayer, int slotNum)
 	{
 		ItemStack origStack = null;
 		Slot slot = (Slot)inventorySlots.get(slotNum);

--- a/src/Common/com/bioxx/tfc/Containers/ContainerGrill.java
+++ b/src/Common/com/bioxx/tfc/Containers/ContainerGrill.java
@@ -47,7 +47,7 @@ public class ContainerGrill extends ContainerTFC
 	}
 
 	@Override
-	public ItemStack transferStackInSlot(EntityPlayer entityplayer, int i)
+	public ItemStack transferStackInSlotTFC(EntityPlayer entityplayer, int i)
 	{
 		Slot slot = (Slot)inventorySlots.get(i);
 		if(slot != null && slot.getHasStack())

--- a/src/Common/com/bioxx/tfc/Containers/ContainerHorseInventoryTFC.java
+++ b/src/Common/com/bioxx/tfc/Containers/ContainerHorseInventoryTFC.java
@@ -125,7 +125,7 @@ public class ContainerHorseInventoryTFC extends ContainerTFC
 	/**
 	 * Called when a player shift-clicks on a slot. You must override this or you will crash when someone does that.
 	 */
-	public ItemStack transferStackInSlot(EntityPlayer player, int par2)
+	public ItemStack transferStackInSlotTFC(EntityPlayer player, int par2)
 	{
 		/*
 		ItemStack itemstack = null;

--- a/src/Common/com/bioxx/tfc/Containers/ContainerLargeVessel.java
+++ b/src/Common/com/bioxx/tfc/Containers/ContainerLargeVessel.java
@@ -46,7 +46,7 @@ public class ContainerLargeVessel extends ContainerBarrel
 	}
 
 	@Override
-	public ItemStack transferStackInSlot(EntityPlayer entityplayer, int i)
+	public ItemStack transferStackInSlotTFC(EntityPlayer entityplayer, int i)
 	{
 		Slot slot = (Slot)inventorySlots.get(i);
 		if(slot != null && slot.getHasStack())

--- a/src/Common/com/bioxx/tfc/Containers/ContainerLiquidVessel.java
+++ b/src/Common/com/bioxx/tfc/Containers/ContainerLiquidVessel.java
@@ -205,7 +205,7 @@ public class ContainerLiquidVessel extends ContainerTFC
 	}
 
 	@Override
-	public ItemStack transferStackInSlot(EntityPlayer player, int clickedIndex)
+	public ItemStack transferStackInSlotTFC(EntityPlayer player, int clickedIndex)
 	{
 		ItemStack returnedStack = null;
 		Slot clickedSlot = (Slot)this.inventorySlots.get(clickedIndex);

--- a/src/Common/com/bioxx/tfc/Containers/ContainerLogPile.java
+++ b/src/Common/com/bioxx/tfc/Containers/ContainerLogPile.java
@@ -50,7 +50,7 @@ public class ContainerLogPile extends ContainerTFC
 	 * Called to transfer a stack from one inventory to the other eg. when shift clicking.
 	 */
 	@Override
-	public ItemStack transferStackInSlot(EntityPlayer player, int clickedIndex)
+	public ItemStack transferStackInSlotTFC(EntityPlayer player, int clickedIndex)
 	{
 		ItemStack var2 = null;
 		Slot var3 = (Slot)this.inventorySlots.get(clickedIndex);

--- a/src/Common/com/bioxx/tfc/Containers/ContainerMold.java
+++ b/src/Common/com/bioxx/tfc/Containers/ContainerMold.java
@@ -167,7 +167,7 @@ public class ContainerMold extends ContainerTFC
 	}
 
 	@Override
-	public ItemStack transferStackInSlot(EntityPlayer entityplayer, int clickedSlot)
+	public ItemStack transferStackInSlotTFC(EntityPlayer entityplayer, int clickedSlot)
 	{
 		Slot slot = (Slot)inventorySlots.get(clickedSlot);
 		Slot slot1 = (Slot)inventorySlots.get(0);

--- a/src/Common/com/bioxx/tfc/Containers/ContainerNestBox.java
+++ b/src/Common/com/bioxx/tfc/Containers/ContainerNestBox.java
@@ -40,7 +40,7 @@ public class ContainerNestBox extends ContainerTFC
 	}
 
 	@Override
-	public ItemStack transferStackInSlot(EntityPlayer player, int clickedIndex)
+	public ItemStack transferStackInSlotTFC(EntityPlayer player, int clickedIndex)
 	{
 		ItemStack returnedStack = null;
 		Slot clickedSlot = (Slot)this.inventorySlots.get(clickedIndex);

--- a/src/Common/com/bioxx/tfc/Containers/ContainerQuern.java
+++ b/src/Common/com/bioxx/tfc/Containers/ContainerQuern.java
@@ -69,7 +69,7 @@ public class ContainerQuern extends ContainerTFC
 	}
 
 	@Override
-	public ItemStack transferStackInSlot(EntityPlayer player, int clickedIndex)
+	public ItemStack transferStackInSlotTFC(EntityPlayer player, int clickedIndex)
 	{
 		ItemStack returnedStack = null;
 		Slot clickedSlot = (Slot)this.inventorySlots.get(clickedIndex);

--- a/src/Common/com/bioxx/tfc/Containers/ContainerQuiver.java
+++ b/src/Common/com/bioxx/tfc/Containers/ContainerQuiver.java
@@ -112,7 +112,7 @@ public class ContainerQuiver extends ContainerTFC
 	}
 
 	@Override
-	public ItemStack transferStackInSlot(EntityPlayer player, int clickedIndex)
+	public ItemStack transferStackInSlotTFC(EntityPlayer player, int clickedIndex)
 	{
 		ItemStack returnedStack = null;
 		Slot clickedSlot = (Slot)this.inventorySlots.get(clickedIndex);

--- a/src/Common/com/bioxx/tfc/Containers/ContainerSluice.java
+++ b/src/Common/com/bioxx/tfc/Containers/ContainerSluice.java
@@ -41,7 +41,7 @@ public class ContainerSluice extends ContainerTFC
 	}
 
 	@Override
-	public ItemStack transferStackInSlot(EntityPlayer player, int i)
+	public ItemStack transferStackInSlotTFC(EntityPlayer player, int i)
 	{
 		Slot slot = (Slot)inventorySlots.get(i);
 		Slot slotpaper = (Slot)inventorySlots.get(1);

--- a/src/Common/com/bioxx/tfc/Containers/ContainerSpecialCrafting.java
+++ b/src/Common/com/bioxx/tfc/Containers/ContainerSpecialCrafting.java
@@ -69,7 +69,7 @@ public class ContainerSpecialCrafting extends ContainerTFC
 	 * @return 
 	 */
 	@Override
-	public ItemStack transferStackInSlot(EntityPlayer player, int clickedIndex)
+	public ItemStack transferStackInSlotTFC(EntityPlayer player, int clickedIndex)
 	{
 		ItemStack isTemp = null;
 		Slot grabbedSlot = (Slot)this.inventorySlots.get(clickedIndex);

--- a/src/Common/com/bioxx/tfc/Containers/ContainerTFC.java
+++ b/src/Common/com/bioxx/tfc/Containers/ContainerTFC.java
@@ -3,6 +3,7 @@ package com.bioxx.tfc.Containers;
 import com.bioxx.tfc.api.TFC_ItemHeat;
 
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.inventory.Container;
 import net.minecraft.inventory.ICrafting;
 import net.minecraft.inventory.Slot;
@@ -239,4 +240,26 @@ public class ContainerTFC extends Container
 
 		return is3Tags.equals(is4Tags) &&  Math.abs(temp3 - temp4) < 5;
 	}
+	
+	public ItemStack transferStackInSlotTFC(EntityPlayer entityplayer, int slotNum)
+	{
+		return super.transferStackInSlot(entityplayer, slotNum);
+	}
+	
+	@Override
+	final public ItemStack transferStackInSlot(EntityPlayer entityplayer, int slotNum)
+	{
+		Slot slot = (Slot)this.inventorySlots.get( slotNum );
+		ItemStack is = transferStackInSlotTFC(entityplayer, slotNum);
+		
+		// send a packet to make sure that the item is removed; that it stays removed.
+		if ( ! slot.getHasStack() && entityplayer instanceof EntityPlayerMP && ! entityplayer.worldObj.isRemote )
+		{
+			EntityPlayerMP mp = (EntityPlayerMP) entityplayer;
+			mp.sendSlotContents( this, slot.slotNumber, slot.getStack() );
+		}
+		
+		return is;
+	}
+	
 }

--- a/src/Common/com/bioxx/tfc/Containers/ContainerVessel.java
+++ b/src/Common/com/bioxx/tfc/Containers/ContainerVessel.java
@@ -191,7 +191,7 @@ public class ContainerVessel extends ContainerTFC
 	}
 
 	@Override
-	public ItemStack transferStackInSlot(EntityPlayer player, int clickedIndex)
+	public ItemStack transferStackInSlotTFC(EntityPlayer player, int clickedIndex)
 	{
 		ItemStack returnedStack = null;
 		Slot clickedSlot = (Slot)this.inventorySlots.get(clickedIndex);

--- a/src/Common/com/bioxx/tfc/Containers/ContainerWorkbench.java
+++ b/src/Common/com/bioxx/tfc/Containers/ContainerWorkbench.java
@@ -90,7 +90,7 @@ public class ContainerWorkbench extends ContainerTFC
 	}
 
 	@Override
-	public ItemStack transferStackInSlot(EntityPlayer par1EntityPlayer, int par2)
+	public ItemStack transferStackInSlotTFC(EntityPlayer par1EntityPlayer, int par2)
 	{
 		ItemStack var3 = null;
 		Slot var4 = (Slot)this.inventorySlots.get(par2);


### PR DESCRIPTION
I asked on IRC about these, and I heard that bugs with shift clicking are ignored by the devs, so I thought maybe I would offer to fix it instead.

The Bug: Shift click cooling ingot into a large vessel of water, result - ghosted ingot in inventory.

The Reason: The issue it self was caused because the container is rapid firing the updates for the ingot temp, so when the client moved the ingot, a moment later it would hear from the server of 20 ms ago that that slot should be a cooling ingot ( thus a ghost is born )

My Solution: Just have the server send the empty slot when shift clicking; results in clearing any ghosts the moment they appear.

I have tested this personally in dev, let me know if you need anything else from me.

Sorry I had to edit so many files, but its the only way that made sense to make sure it sticks, with all the containers.
