### PR TITLE
Sync Ingot Piles from server to clients when placing ingots.

### DIFF
--- a/src/Common/com/bioxx/tfc/TileEntities/TEIngotPile.java
+++ b/src/Common/com/bioxx/tfc/TileEntities/TEIngotPile.java
@@ -178,6 +178,7 @@ public class TEIngotPile extends NetworkTileEntity implements IInventory
 			if(storage[index].stackSize > 0)
 			{
 				storage[index] = new ItemStack(storage[index].getItem(), storage[index].stackSize + count, storage[index].getItemDamage());
+				worldObj.markBlockForUpdate( xCoord, yCoord, zCoord );
 			}
 		}
 		updateNeighbours();


### PR DESCRIPTION
Pretty straight forward fix to a pretty straight forward bug; ingot piles were not getting sent to other players on servers.

Tested in Dev on a Lan game.
