### PR TITLE
Make animals not drop re-ridiculously small piles of meat.

### DIFF
--- a/src/API/com/bioxx/tfc/api/Constant/Global.java
+++ b/src/API/com/bioxx/tfc/api/Constant/Global.java
@@ -121,6 +121,7 @@ public class Global
 	 */
 	public static double FOOD_DECAY_RATE = 1.0170378966055869517978300569768f;
 	public static float FOOD_MAX_WEIGHT = 160;
+	public static float FOOD_MIN_DROP_WEIGHT = 0.1f;
 
 	public static int SEALEVEL = 144;
 }

--- a/src/Common/com/bioxx/tfc/Handlers/EntityLivingHandler.java
+++ b/src/Common/com/bioxx/tfc/Handlers/EntityLivingHandler.java
@@ -308,7 +308,7 @@ public class EntityLivingHandler
 						float oldWeight = Food.getWeight(ei.getEntityItem());
 						Food.setWeight(ei.getEntityItem(), 0);
 						float newWeight = oldWeight * (TFC_Core.getSkillStats(p).getSkillMultiplier(Global.SKILL_BUTCHERING)+0.01f);
-						while (newWeight > 0)
+						while (newWeight >= Global.FOOD_MIN_DROP_WEIGHT)
 						{
 							float fw = Helper.roundNumber(Math.min(Global.FOOD_MAX_WEIGHT, newWeight), 10);
 							if (fw < Global.FOOD_MAX_WEIGHT)


### PR DESCRIPTION
Feel free to dis-regard this, but I think its a reasonable change; however I'll respect your decision either way.

A lot of people are thinking that the new bunching skill resulting in ~0 weight food items is a bug, this would make it so they just won't drop, so less bug like, and more "your not skilled enough to butcher this animal" yet like.
