### PR TITLE
ProPick was using server language since running there, moved to client

### DIFF
--- a/src/Common/com/bioxx/tfc/Items/Tools/ItemProPick.java
+++ b/src/Common/com/bioxx/tfc/Items/Tools/ItemProPick.java
@@ -61,7 +61,7 @@ public class ItemProPick extends ItemTerra
 	public boolean onItemUse(ItemStack itemStack, EntityPlayer player, World world, int x, int y, int z, int side, float hitX, float hitY, float hitZ)
 	{
 		Block block = world.getBlock(x, y, z);
-		if (!world.isRemote)
+		if (world.isRemote)
 		{
 			// Negated the old condition and exiting the method here instead.
 			if (block == TFCBlocks.ToolRack)


### PR DESCRIPTION
Please check this one, I am not sure if it is needed that the ProPick runs on the server.

Should solve the problem that ProPicks messages were not show in the client language:
http://terrafirmacraft.com/f/topic/7005-797there-was-a-problem-about-propicks-gui/#entry94223
