### PR TITLE
Rewrote Detailed Block Rendering.

### DIFF
--- a/src/Common/com/bioxx/tfc/Render/Blocks/RenderDetailed.java
+++ b/src/Common/com/bioxx/tfc/Render/Blocks/RenderDetailed.java
@@ -2,42 +2,38 @@ package com.bioxx.tfc.Render.Blocks;
 
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
-import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.util.IIcon;
 
-import com.bioxx.tfc.Render.RenderBlocksFixUV;
+import com.bioxx.tfc.Render.RenderBlocksLightCache;
 import com.bioxx.tfc.TileEntities.TEDetailed;
 
 public class RenderDetailed 
 {
-	private static RenderBlocksFixUV renderer;
+	private static RenderBlocksLightCache renderer;
 
 	public static boolean renderBlockDetailed(Block block, int i, int j, int k, RenderBlocks renderblocks)
 	{
 		TEDetailed te = (TEDetailed) renderblocks.blockAccess.getTileEntity(i, j, k);
-		int md = renderblocks.blockAccess.getBlockMetadata(i, j, k);
 
 		if(renderer == null)
-			renderer = new RenderBlocksFixUV(renderblocks);
+			renderer = new RenderBlocksLightCache(renderblocks);
 		else
 			renderer.update(renderblocks);
 
+		// Capture full block lighting data...
+		renderer.disableRender();
+		renderer.setRenderBounds(0,0,0,1,1,1);
+		renderer.renderStandardBlock(block, i, j, k);
+		renderer.enableRender();
+		
 		if(te.TypeID <= 0)
 			return false;
 
 		int type = te.TypeID;
 		int meta = te.MetaID;
 
-		boolean breaking = false;
-		if(renderer.overrideBlockTexture != null)
-			breaking = true;
-		else
-			renderer.setOverrideBlockTexture(Block.getBlockById(te.TypeID).getIcon(0, te.MetaID));
-
-		int l = block.colorMultiplier(renderblocks.blockAccess, i, j, k);
-		float f = (l >> 16 & 255) / 255.0F;
-		float f1 = (l >> 8 & 255) / 255.0F;
-		float f2 = (l & 255) / 255.0F;
-
+		IIcon myTexture = renderblocks.overrideBlockTexture == null ? Block.getBlockById(te.TypeID).getIcon(0, te.MetaID) : renderblocks.overrideBlockTexture;
+		
 		for(int subX = 0; subX < 2; subX++)
 		{
 			for(int subZ = 0; subZ < 2; subZ++)
@@ -46,7 +42,7 @@ public class RenderDetailed
 				{
 					if(!te.isQuadSolid(subX, subY, subZ))
 					{
-						renderMiniBlock(block, i, j, k, subX, subY, subZ, renderer, te, type, meta);
+						renderMiniBlock(block, i, j, k, subX, subY, subZ, te, type, meta, myTexture);
 					}
 					else
 					{
@@ -58,7 +54,7 @@ public class RenderDetailed
 						float maxZ = minZ + 0.5f;
 
 						renderer.setRenderBounds(minX, minY, minZ, maxX, maxY, maxZ);
-						renderer.renderStandardBlock(block, i, j, k);
+						renderer.renderCachedBlock(block, i, j, k, myTexture);
 					}
 				}
 			}
@@ -67,13 +63,8 @@ public class RenderDetailed
 		return true;
 	}
 
-	private static void renderMiniBlock(Block block, int i, int j, int k, int x, int y, int z, RenderBlocks renderblocks, TEDetailed te, int type, int meta)
+	private static void renderMiniBlock(Block block, int i, int j, int k, int x, int y, int z, TEDetailed te, int type, int meta, IIcon myTexture)
 	{
-		int l = block.colorMultiplier(renderblocks.blockAccess, i, j, k);
-		float f = (l >> 16 & 255) / 255.0F;
-		float f1 = (l >> 8 & 255) / 255.0F;
-		float f2 = (l & 255) / 255.0F;
-
 		for(int subX = x*4; subX < 4+x*4; subX++)
 		{
 			for(int subZ = z*4; subZ < 4+z*4; subZ++)
@@ -81,72 +72,43 @@ public class RenderDetailed
 				for(int subY = y*4; subY < 4+y*4; subY++)
 				{
 					boolean subExists = isOpaque(te,subX, subY, subZ);
-					if(subExists)
+					if ( subExists )
 					{
-						float minX = 0.125f*subX;
-						float maxX = minX + 0.125f;
-						float minY = 0.125f*subY;
-						float maxY = minY + 0.125f;
-						float minZ = 0.125f*subZ;
-						float maxZ = minZ + 0.125f;
-
-						renderblocks.setRenderBounds(minX, minY, minZ, maxX, maxY, maxZ);
-						renderblocks.renderStandardBlock(block, i, j, k);
+						boolean isVisible = isTransparent(te,subX-1, subY, subZ) || 
+								isTransparent(te,subX+1, subY, subZ) ||
+								isTransparent(te,subX, subY-1, subZ) ||
+								isTransparent(te,subX, subY+1, subZ) ||
+								isTransparent(te,subX, subY, subZ-1) ||
+								isTransparent(te,subX, subY, subZ+1);
+						
+						if ( isVisible )
+						{
+							float minX = 0.125f*subX;
+							float maxX = minX + 0.125f;
+							float minY = 0.125f*subY;
+							float maxY = minY + 0.125f;
+							float minZ = 0.125f*subZ;
+							float maxZ = minZ + 0.125f;
+	
+							renderer.setRenderBounds(minX, minY, minZ, maxX, maxY, maxZ);
+							renderer.renderCachedBlock(block, i, j, k, myTexture);
+						}
 					}
 				}
 			}
 		}
 	}
 
-	public static boolean renderStandardBlock(Block block, RenderBlocks renderblocks, int x, int y, int z, int meta)
-	{
-		renderblocks.enableAO = false;
-		Tessellator tess = Tessellator.instance;
-
-		float r = 0.5F;
-		float g = 0.8F;
-		float b = 0.6F;
-		float var17 = r;
-		float var18 = g;
-		float var19 = b;
-		float var20 = r;
-		float var21 = g;
-		float var22 = b;
-		float var23 = r;
-		float var24 = g;
-		float var25 = b;
-
-		int var26 = block.getMixedBrightnessForBlock(renderblocks.blockAccess, x, y, z);
-
-		tess.setBrightness(renderblocks.renderMinY > 0.0D ? var26 : block.getMixedBrightnessForBlock(renderblocks.blockAccess, x, y - 1, z));
-		tess.setColorOpaque_F(var17, var20, var23);
-		renderblocks.renderFaceYNeg(block, x, y, z, block.getIcon(0, meta));
-
-		tess.setBrightness(renderblocks.renderMaxY < 1.0D ? var26 : block.getMixedBrightnessForBlock(renderblocks.blockAccess, x, y + 1, z));
-		tess.setColorOpaque_F(1, 1, 1);
-		renderblocks.renderFaceYPos(block, x, y, z, block.getIcon(1, meta));
-
-		tess.setBrightness(renderblocks.renderMaxX > 0.0D ? var26 : block.getMixedBrightnessForBlock(renderblocks.blockAccess, x+1, y, z));
-		tess.setColorOpaque_F(var18, var21, var24);
-		renderblocks.renderFaceXPos(block, x, y, z, block.getIcon(2, meta));
-
-		tess.setBrightness(renderblocks.renderMinX < 1.0D ? var26 : block.getMixedBrightnessForBlock(renderblocks.blockAccess, x-1, y, z));
-		tess.setColorOpaque_F(var18, var21, var24);
-		renderblocks.renderFaceXNeg(block, x, y, z, block.getIcon(3, meta));
-
-		tess.setBrightness(renderblocks.renderMinZ > 0.0D ? var26 : block.getMixedBrightnessForBlock(renderblocks.blockAccess, x, y, z-1));
-		tess.setColorOpaque_F(var19, var22, var25);
-		renderblocks.renderFaceZNeg(block, x, y, z, block.getIcon(4, meta));
-
-		tess.setBrightness(renderblocks.renderMaxZ < 1.0D ? var26 : block.getMixedBrightnessForBlock(renderblocks.blockAccess, x, y, z+1));
-		tess.setColorOpaque_F(var19, var22, var25);
-		renderblocks.renderFaceZPos(block, x, y, z, block.getIcon(5, meta));
-
-		return true;
-	}
-
 	public static boolean isOpaque(TEDetailed te, int x, int y, int z)
 	{
 		return te.data.get((x * 8 + z)*8 + y);
+	}
+	
+	public static boolean isTransparent(TEDetailed te, int x, int y, int z)
+	{
+		if ( x < 0 || x >= 8 || y < 0 || y >= 8 || z < 0 || z >= 8 )
+			return true;
+		
+		return ! te.data.get((x * 8 + z)*8 + y);
 	}
 }

--- a/src/Common/com/bioxx/tfc/Render/RenderBlocksLightCache.java
+++ b/src/Common/com/bioxx/tfc/Render/RenderBlocksLightCache.java
@@ -1,0 +1,374 @@
+package com.bioxx.tfc.Render;
+
+import java.util.EnumSet;
+
+import net.minecraft.block.Block;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.RenderBlocks;
+import net.minecraft.util.IIcon;
+import net.minecraftforge.common.util.ForgeDirection;
+
+public class RenderBlocksLightCache extends RenderBlocksFixUV
+{
+	private EnumSet<ForgeDirection> facesToDraw = EnumSet.allOf( ForgeDirection.class );
+	
+	private RenderFaceData sides[]  = new RenderFaceData[6];
+	
+	private static class RenderPointData
+	{
+		int brightness;
+		float r,g,b;
+	};
+	
+	private static class RenderFaceData
+	{
+		
+		private int cacheBrightnessTopLeft;
+		private int cacheBrightnessBottomLeft;
+		private int cacheBrightnessBottomRight;
+		private int cacheBrightnessTopRight;
+		
+		private float cacheColorRedTopLeft;
+		private float cacheColorRedBottomLeft;
+		private float cacheColorRedBottomRight;
+		private float cacheColorRedTopRight;
+		
+		private float cacheColorGreenTopLeft;
+		private float cacheColorGreenBottomLeft;
+		private float cacheColorGreenBottomRight;
+		private float cacheColorGreenTopRight;
+		
+		private float cacheColorBlueTopLeft;
+		private float cacheColorBlueBottomLeft;
+		private float cacheColorBlueBottomRight;
+		private float cacheColorBlueTopRight;
+		
+		public RenderFaceData(RenderBlocks rb)
+		{
+			cacheBrightnessTopLeft = rb.brightnessTopLeft;
+			cacheBrightnessBottomLeft = rb.brightnessBottomLeft;
+			cacheBrightnessBottomRight = rb.brightnessBottomRight;
+			cacheBrightnessTopRight = rb.brightnessTopRight;
+			
+			cacheColorRedTopLeft = rb.colorRedTopLeft;
+			cacheColorRedBottomLeft = rb.colorRedBottomLeft;
+			cacheColorRedBottomRight = rb.colorRedBottomRight;
+			cacheColorRedTopRight = rb.colorRedTopRight;
+			
+			cacheColorGreenTopLeft = rb.colorGreenTopLeft;
+			cacheColorGreenBottomLeft = rb.colorGreenBottomLeft;
+			cacheColorGreenBottomRight = rb.colorGreenBottomRight;
+			cacheColorGreenTopRight = rb.colorGreenTopRight;
+			
+			cacheColorBlueTopLeft = rb.colorBlueTopLeft;
+			cacheColorBlueBottomLeft = rb.colorBlueBottomLeft;
+			cacheColorBlueBottomRight = rb.colorBlueBottomRight;
+			cacheColorBlueTopRight = rb.colorBlueTopRight;
+		}
+		
+		public RenderPointData getCachedValue( double leftRight, double topBottom)
+		{
+			RenderPointData o = new RenderPointData();
+			
+			// interpolate colors
+			double rTop = cacheColorRedTopLeft * leftRight + (1.0d - leftRight) * cacheColorRedTopRight;
+			double rBottom = cacheColorRedBottomLeft * leftRight + (1.0d - leftRight) * cacheColorRedBottomRight;
+			o.r = (float) (rTop * topBottom + rBottom * (1.0d - topBottom));
+			
+			double gTop = cacheColorGreenTopLeft * leftRight + (1.0d - leftRight) * cacheColorGreenTopRight;
+			double gBottom = cacheColorGreenBottomLeft * leftRight + (1.0d - leftRight) * cacheColorGreenBottomRight;
+			o.g = (float) (gTop * topBottom + gBottom * (1.0d - topBottom));
+			
+			double bTop = cacheColorBlueTopLeft * leftRight + (1.0d - leftRight) * cacheColorBlueTopRight;
+			double bBottom = cacheColorBlueBottomLeft * leftRight + (1.0d - leftRight) * cacheColorBlueBottomRight;
+			o.b = (float) (bTop * topBottom + bBottom * (1.0d - topBottom));
+			
+			// interpolate lighting, do sky and block light separately
+			double highTop = (cacheBrightnessTopLeft >> 16 & 0xff) * leftRight + (1.0d - leftRight) * (cacheBrightnessTopRight >> 16 & 0xff);
+			double highBottom = (cacheBrightnessBottomLeft >> 16 & 0xff) * leftRight + (1.0d - leftRight) * (cacheBrightnessBottomRight >> 16 & 0xff);
+			int high = ((int) (highTop * topBottom + highBottom * (1.0d - topBottom))) & 0xff;
+			
+			double lowTop = ((cacheBrightnessTopLeft & 0xff)) * leftRight + (1.0d - leftRight) * ((cacheBrightnessTopRight & 0xff));
+			double lowBottom = ((cacheBrightnessBottomLeft & 0xff)) * leftRight + (1.0d - leftRight) * ((cacheBrightnessBottomRight & 0xff));
+			int low = ((int) (lowTop * topBottom + lowBottom * (1.0d - topBottom))) & 0xff;
+			
+			// merge sky and block light.
+			o.brightness = (high << 16) | low;
+			
+			return o;
+		}
+	
+	};
+	
+	public RenderBlocksLightCache(RenderBlocks old)
+	{
+		super( old );
+	}
+	
+	/**
+	* enable or disable caching
+	*/
+	public void disableRender()
+	{
+		facesToDraw = EnumSet.noneOf( ForgeDirection.class );
+	}
+	
+	public void enableRender()
+	{
+		facesToDraw = EnumSet.allOf( ForgeDirection.class );
+	}
+	
+	/**
+	* the following are just to enable and disable the actual drawing.
+	*/
+	
+	@Override
+	public void renderFaceZNeg(Block a, double b, double c, double d, IIcon e)
+	{
+		if ( ! facesToDraw.contains( ForgeDirection.NORTH ) )
+		{
+			saveData( ForgeDirection.NORTH );
+			return;
+		}
+		
+		super.renderFaceZNeg(a, b, c, d, e);
+	}
+	
+	@Override
+	public void renderFaceXPos(Block a, double b, double c, double d, IIcon e)
+	{
+		if ( ! facesToDraw.contains( ForgeDirection.EAST ) )
+		{
+			saveData( ForgeDirection.EAST );
+			return;
+		}
+		
+		super.renderFaceXPos(a, b, c, d, e);
+	}
+	
+	
+	@Override
+	public void renderFaceXNeg(Block a, double b, double c, double d, IIcon e)
+	{
+		if ( ! facesToDraw.contains( ForgeDirection.WEST ) )
+		{
+			saveData( ForgeDirection.WEST );
+			return;
+		}
+		
+		super.renderFaceXNeg(a, b, c, d, e);
+	}
+	
+	@Override
+	public void renderFaceYNeg(Block a, double b, double c, double d, IIcon e)
+	{
+		if ( ! facesToDraw.contains( ForgeDirection.DOWN ) )
+		{
+			saveData( ForgeDirection.DOWN );
+			return;
+		}
+		
+		super.renderFaceYNeg(a, b, c, d, e);
+	}
+	
+	@Override
+	public void renderFaceYPos(Block a, double b, double c, double d, IIcon e)
+	{
+		if ( ! facesToDraw.contains( ForgeDirection.UP ) )
+		{
+			saveData( ForgeDirection.UP );
+			return;
+		}
+		
+		super.renderFaceYPos(a, b, c, d, e);
+	}
+	
+	@Override
+	public void renderFaceZPos(Block a, double b, double c, double d, IIcon e)
+	{
+		if ( ! facesToDraw.contains( ForgeDirection.SOUTH ) )
+		{
+			saveData( ForgeDirection.SOUTH );
+			return;
+		}
+		
+		super.renderFaceZPos(a, b, c, d, e);
+	}
+	
+	private void saveData(ForgeDirection side)
+	{
+		sides[ side.ordinal() ] = new RenderFaceData( this );
+	}
+	
+	public void renderCachedBlock(Block block, int i, int j, int k, IIcon myTexture)
+	{
+		this.enableAO = Minecraft.isAmbientOcclusionEnabled();
+		RenderPointData rpd;
+		
+		
+		rpd = sides[ ForgeDirection.EAST.ordinal() ].getCachedValue( 1.0d - renderMaxY, renderMaxZ );
+		colorRedTopLeft 	= rpd.r;
+		colorGreenTopLeft	= rpd.g;
+		colorBlueTopLeft	= rpd.b;
+		brightnessTopLeft	= rpd.brightness;
+		
+		rpd = sides[ ForgeDirection.EAST.ordinal() ].getCachedValue( 1.0d - renderMinY, renderMaxZ );
+		colorRedTopRight	= rpd.r;
+		colorGreenTopRight	= rpd.g;
+		colorBlueTopRight	= rpd.b;
+		brightnessTopRight	= rpd.brightness;
+		
+		rpd = sides[ ForgeDirection.EAST.ordinal() ].getCachedValue( 1.0d - renderMinY, renderMinZ );
+		colorRedBottomRight		= rpd.r;
+		colorGreenBottomRight	= rpd.g;
+		colorBlueBottomRight	= rpd.b;
+		brightnessBottomRight	= rpd.brightness;
+		
+		rpd = sides[ ForgeDirection.EAST.ordinal() ].getCachedValue( 1.0d - renderMaxY, renderMinZ );
+		colorRedBottomLeft		= rpd.r;
+		colorGreenBottomLeft	= rpd.g;
+		colorBlueBottomLeft		= rpd.b;
+		brightnessBottomLeft	= rpd.brightness;
+		
+		renderFaceXPos(block, (double)i, (double)j, (double)k, myTexture );
+		
+		
+		rpd = sides[ ForgeDirection.WEST.ordinal() ].getCachedValue( renderMaxY, renderMaxZ );
+		colorRedTopLeft 	= rpd.r;
+		colorGreenTopLeft	= rpd.g;
+		colorBlueTopLeft	= rpd.b;
+		brightnessTopLeft	= rpd.brightness;
+		
+		rpd = sides[ ForgeDirection.WEST.ordinal() ].getCachedValue( renderMaxY, renderMinZ );
+		colorRedBottomLeft		= rpd.r;
+		colorGreenBottomLeft	= rpd.g;
+		colorBlueBottomLeft		= rpd.b;
+		brightnessBottomLeft	= rpd.brightness;
+		
+		rpd = sides[ ForgeDirection.WEST.ordinal() ].getCachedValue( renderMinY, renderMinZ );
+		colorRedBottomRight		= rpd.r;
+		colorGreenBottomRight	= rpd.g;
+		colorBlueBottomRight	= rpd.b;
+		brightnessBottomRight	= rpd.brightness;
+		
+		rpd = sides[ ForgeDirection.WEST.ordinal() ].getCachedValue( renderMinY, renderMaxZ );
+		colorRedTopRight	= rpd.r;
+		colorGreenTopRight	= rpd.g;
+		colorBlueTopRight	= rpd.b;
+		brightnessTopRight	= rpd.brightness;
+		
+		renderFaceXNeg(block, (double)i, (double)j, (double)k, myTexture );
+		
+		
+		rpd = sides[ ForgeDirection.SOUTH.ordinal() ].getCachedValue( 1.0d - renderMinX, renderMaxY );
+		colorRedTopLeft 	= rpd.r;
+		colorGreenTopLeft	= rpd.g;
+		colorBlueTopLeft	= rpd.b;
+		brightnessTopLeft	= rpd.brightness;
+		
+		rpd = sides[ ForgeDirection.SOUTH.ordinal() ].getCachedValue( 1.0d - renderMinX, renderMinY );
+		colorRedBottomLeft		= rpd.r;
+		colorGreenBottomLeft	= rpd.g;
+		colorBlueBottomLeft		= rpd.b;
+		brightnessBottomLeft	= rpd.brightness;
+		
+		rpd = sides[ ForgeDirection.SOUTH.ordinal() ].getCachedValue( 1.0d - renderMaxX, renderMinY );
+		colorRedBottomRight		= rpd.r;
+		colorGreenBottomRight	= rpd.g;
+		colorBlueBottomRight	= rpd.b;
+		brightnessBottomRight	= rpd.brightness;
+		
+		rpd = sides[ ForgeDirection.SOUTH.ordinal() ].getCachedValue( 1.0d - renderMaxX, renderMaxY );
+		colorRedTopRight	= rpd.r;
+		colorGreenTopRight	= rpd.g;
+		colorBlueTopRight	= rpd.b;
+		brightnessTopRight	= rpd.brightness;
+		
+		renderFaceZPos(block, (double)i, (double)j, (double)k, myTexture );
+		
+		
+		rpd = sides[ ForgeDirection.NORTH.ordinal() ].getCachedValue( renderMaxY, 1.0d - renderMinX );
+		colorRedTopLeft 	= rpd.r;
+		colorGreenTopLeft	= rpd.g;
+		colorBlueTopLeft	= rpd.b;
+		brightnessTopLeft	= rpd.brightness;
+		
+		rpd = sides[ ForgeDirection.NORTH.ordinal() ].getCachedValue( renderMaxY, 1.0d - renderMaxX );
+		colorRedTopRight	= rpd.r;
+		colorGreenTopRight	= rpd.g;
+		colorBlueTopRight	= rpd.b;
+		brightnessTopRight	= rpd.brightness;
+		
+		rpd = sides[ ForgeDirection.NORTH.ordinal() ].getCachedValue( renderMinY, 1.0d - renderMaxX );
+		colorRedBottomRight		= rpd.r;
+		colorGreenBottomRight	= rpd.g;
+		colorBlueBottomRight	= rpd.b;
+		brightnessBottomRight	= rpd.brightness;
+		
+		rpd = sides[ ForgeDirection.NORTH.ordinal() ].getCachedValue( renderMinY, 1.0d - renderMinX );
+		colorRedBottomLeft		= rpd.r;
+		colorGreenBottomLeft	= rpd.g;
+		colorBlueBottomLeft		= rpd.b;
+		brightnessBottomLeft	= rpd.brightness;
+		
+		renderFaceZNeg(block, (double)i, (double)j, (double)k, myTexture );
+		
+		
+		rpd = sides[ ForgeDirection.UP.ordinal() ].getCachedValue( renderMaxX, renderMaxZ );
+		colorRedTopLeft 	= rpd.r;
+		colorGreenTopLeft	= rpd.g;
+		colorBlueTopLeft	= rpd.b;
+		brightnessTopLeft	= rpd.brightness;
+		
+		rpd = sides[ ForgeDirection.UP.ordinal() ].getCachedValue( renderMaxX, renderMinZ );
+		colorRedBottomLeft		= rpd.r;
+		colorGreenBottomLeft	= rpd.g;
+		colorBlueBottomLeft		= rpd.b;
+		brightnessBottomLeft	= rpd.brightness;
+		
+		rpd = sides[ ForgeDirection.UP.ordinal() ].getCachedValue( renderMinX, renderMinZ );
+		colorRedBottomRight		= rpd.r;
+		colorGreenBottomRight	= rpd.g;
+		colorBlueBottomRight	= rpd.b;
+		brightnessBottomRight	= rpd.brightness;
+		
+		rpd = sides[ ForgeDirection.UP.ordinal() ].getCachedValue( renderMinX, renderMaxZ );
+		colorRedTopRight	= rpd.r;
+		colorGreenTopRight	= rpd.g;
+		colorBlueTopRight	= rpd.b;
+		brightnessTopRight	= rpd.brightness;
+		
+		renderFaceYPos(block, (double)i, (double)j, (double)k, myTexture );
+		
+		
+		rpd = sides[ ForgeDirection.DOWN.ordinal() ].getCachedValue( 1.0d - renderMinX, renderMaxZ );
+		colorRedTopLeft 	= rpd.r;
+		colorGreenTopLeft	= rpd.g;
+		colorBlueTopLeft	= rpd.b;
+		brightnessTopLeft	= rpd.brightness;
+		
+		rpd = sides[ ForgeDirection.DOWN.ordinal() ].getCachedValue( 1.0d - renderMinX, renderMinZ );
+		colorRedBottomLeft		= rpd.r;
+		colorGreenBottomLeft	= rpd.g;
+		colorBlueBottomLeft		= rpd.b;
+		brightnessBottomLeft	= rpd.brightness;
+		
+		rpd = sides[ ForgeDirection.DOWN.ordinal() ].getCachedValue( 1.0d - renderMaxX, renderMinZ );
+		colorRedBottomRight		= rpd.r;
+		colorGreenBottomRight	= rpd.g;
+		colorBlueBottomRight	= rpd.b;
+		brightnessBottomRight	= rpd.brightness;
+		
+		rpd = sides[ ForgeDirection.DOWN.ordinal() ].getCachedValue( 1.0d - renderMaxX, renderMaxZ );
+		colorRedTopRight	= rpd.r;
+		colorGreenTopRight	= rpd.g;
+		colorBlueTopRight	= rpd.b;
+		brightnessTopRight	= rpd.brightness;
+		
+		renderFaceYNeg(block, (double)i, (double)j, (double)k, myTexture );
+		
+		
+		enableAO = false;
+	}
+
+}


### PR DESCRIPTION
Apologies for the large PR, it kinda spiraled out of control, I originally only intended to make a few minor improvements, but I just couldn't stop until I liked the results.

Using a really long winded cache based system, I replace the render code of detail blocks with one that uses a single lighting calculation and interpolated color/brightness.

I also filtered the rendering to ignore "voxels" that are interior blocks.

Over all the result is vastly improved rendering speed 5-6 detail blocks were causing chunk re-draws to murder the client thread originally, with the new version I had at least 40 and there was no noticeable degradation.

A few notes about quality:
This fixes the breaking animation of detail blocks, and fixed the strange "block like" look that sometimes appears in the brightness, so over all I think the quality is better, the down side is that some sides appear darker then you might expect when they are next to solid blocks.

But a think that the improvement(s) is worth the down side.
