### PR TITLE
Fixed Detailed Block Render Crashes - Removed Tick based Render Blocks Caching.

### DIFF
--- a/src/Common/com/bioxx/tfc/Render/RenderBlocksFixUV.java
+++ b/src/Common/com/bioxx/tfc/Render/RenderBlocksFixUV.java
@@ -1,7 +1,5 @@
 package com.bioxx.tfc.Render;
 
-import com.bioxx.tfc.Core.TFC_Time;
-
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.Tessellator;
@@ -9,20 +7,15 @@ import net.minecraft.util.IIcon;
 
 public class RenderBlocksFixUV extends RenderBlocks
 {
-	private long lastUpdate = 0;
+	
 	public RenderBlocksFixUV(RenderBlocks old) 
 	{
 		this.blockAccess = old.blockAccess;
-		lastUpdate = TFC_Time.getTotalTicks();
-		//this.minecraftRB = Minecraft.getMinecraft();
 	}
 
 	public void update(RenderBlocks old)
 	{
-		if(TFC_Time.getTotalTicks() > lastUpdate+10)
-		{
-			this.blockAccess = old.blockAccess;
-		}
+		this.blockAccess = old.blockAccess;
 	}
 
 	@Override


### PR DESCRIPTION
I don't know what the intention is here, but this seems to be causing indexed look up crashes because its hanging on to older render chunks instead of using the latest one provided by MC.

Removing it seems to fix that, and from what I can tell nothing went wrong with the rendering; and no more crashes.
