### PR TITLE
Fix Bottle Deletion with Barrel Interactions.

### DIFF
--- a/src/Common/com/bioxx/tfc/Blocks/Devices/BlockBarrel.java
+++ b/src/Common/com/bioxx/tfc/Blocks/Devices/BlockBarrel.java
@@ -304,14 +304,56 @@ public class BlockBarrel extends BlockTerraContainer
 			ItemStack equippedItem = player.getCurrentEquippedItem();
 			if(FluidContainerRegistry.isFilledContainer(equippedItem) && !te.getSealed())
 			{
-				ItemStack is = te.addLiquid(player.getCurrentEquippedItem());
-				player.inventory.setInventorySlotContents(player.inventory.currentItem, is);
+				ItemStack tmp = equippedItem.copy();
+				tmp.stackSize = 1;
+				equippedItem.stackSize--;
+
+				if ( equippedItem.stackSize == 0 )
+					player.inventory.setInventorySlotContents(player.inventory.currentItem, null);
+				
+				ItemStack is = te.addLiquid(tmp);
+
+				if ( equippedItem.stackSize == 0 && ( is.getMaxStackSize() == 1 || ! player.inventory.hasItemStack(is) ) ) // put buckets in the slot you used them from.
+					player.inventory.setInventorySlotContents(player.inventory.currentItem, is);
+				else
+				{
+					if ( player.inventory.addItemStackToInventory(is) == false )
+						player.dropPlayerItemWithRandomChoice(is, false); // if the new item dosn't fit, drop it.
+				}
+
+				if ( player.inventoryContainer != null )
+				{
+					// for some reason the players inventory won't update without this.
+					player.inventoryContainer.detectAndSendChanges();
+				}
+				
 				return true;
 			}
 			else if(FluidContainerRegistry.isEmptyContainer(equippedItem))
 			{
-				ItemStack is = te.removeLiquid(player.getCurrentEquippedItem());
-				player.inventory.setInventorySlotContents(player.inventory.currentItem, is);
+				ItemStack tmp = equippedItem.copy();
+				tmp.stackSize = 1;
+				equippedItem.stackSize--;
+				
+				if ( equippedItem.stackSize == 0 )
+					player.inventory.setInventorySlotContents(player.inventory.currentItem, null);
+				
+				ItemStack is = te.removeLiquid(tmp);
+
+				if ( equippedItem.stackSize == 0 && ( is.getMaxStackSize() == 1 || ! player.inventory.hasItemStack(is) ) ) // put buckets in the slot you used them from.
+					player.inventory.setInventorySlotContents(player.inventory.currentItem, is);
+				else
+				{
+					if ( player.inventory.addItemStackToInventory(is) == false )
+						player.dropPlayerItemWithRandomChoice(is, false); // if the new item dosn't fit, drop it.
+				}
+				
+				if ( player.inventoryContainer != null )
+				{
+					// for some reason the players inventory won't update without this.
+					player.inventoryContainer.detectAndSendChanges();
+				}
+				
 				return true;
 			}
 			else if(equippedItem != null && (equippedItem.getItem() instanceof ItemBarrels || equippedItem.getItem() instanceof ItemLargeVessel))

--- a/src/Common/com/bioxx/tfc/TileEntities/TEBarrel.java
+++ b/src/Common/com/bioxx/tfc/TileEntities/TEBarrel.java
@@ -361,7 +361,7 @@ public class TEBarrel extends NetworkTileEntity implements IInventory
 
 	public ItemStack addLiquid(ItemStack is)
 	{
-		if(is == null)
+		if(is == null || is.stackSize > 1)
 			return is;
 		if(FluidContainerRegistry.isFilledContainer(is))
 		{
@@ -380,7 +380,7 @@ public class TEBarrel extends NetworkTileEntity implements IInventory
 	 */
 	public ItemStack removeLiquid(ItemStack is)
 	{
-		if(is == null)
+		if(is == null || is.stackSize > 1)
 			return is;
 		if(FluidContainerRegistry.isEmptyContainer(is))
 		{
@@ -534,19 +534,20 @@ public class TEBarrel extends NetworkTileEntity implements IInventory
 
 			if(mode == MODE_IN)
 			{
-				FluidStack inLiquid = FluidContainerRegistry.getFluidForFilledItem(getInputStack());
-				if(inLiquid != null)
+				ItemStack container = getInputStack();
+				FluidStack inLiquid = FluidContainerRegistry.getFluidForFilledItem(container);
+				if(inLiquid != null && container.stackSize == 1)
 				{
 					if(this.fluid == null)
 					{
 						this.fluid = inLiquid.copy();
-						this.setInventorySlotContents(0, FluidContainerRegistry.drainFluidContainer(getInputStack()));
+						this.setInventorySlotContents(0, FluidContainerRegistry.drainFluidContainer(container));
 					}
 					else if(inLiquid.isFluidEqual(this.fluid))
 					{
 						if(addLiquid(inLiquid.amount))
 						{
-							this.setInventorySlotContents(0, FluidContainerRegistry.drainFluidContainer(getInputStack()));
+							this.setInventorySlotContents(0, FluidContainerRegistry.drainFluidContainer(container));
 						}
 					}
 				}


### PR DESCRIPTION
Prevents gui interactions with stack sizes > 1
And re-wrote right click functionality to do 1 item out of the stack at a time.
