### PR TITLE
fixed misplacing a Grill deletes it from the inventory.

### DIFF
--- a/src/Common/com/bioxx/tfc/Items/ItemBlocks/ItemGrill.java
+++ b/src/Common/com/bioxx/tfc/Items/ItemBlocks/ItemGrill.java
@@ -25,13 +25,15 @@ public class ItemGrill extends ItemTerraBlock
 	{
 		if(!world.isRemote)
 		{
-			if(side == 1 && world.isAirBlock(x, y+1, z) && checkSides(world, x, y, z))
+			if(side == 1 && world.isAirBlock(x, y+1, z))
 			{
 				TileEntity te = world.getTileEntity(x, y, z);
-				if(te != null && te instanceof TEFireEntity)
+				if(te != null && te instanceof TEFireEntity && checkSides(world, x, y, z))
 					world.setBlock( x, y+1, z, TFCBlocks.Grill, itemstack.getItemDamage(), 0x2);
 				else if(world.isAirBlock(x, y+2, z) && checkSides(world, x, y+1, z))
 					world.setBlock( x, y+2, z, TFCBlocks.Grill, itemstack.getItemDamage(), 0x2);
+				else
+					return false;  // don't delete misplaced Grill
 				player.inventory.mainInventory[player.inventory.currentItem].stackSize--;
 				return true;
 			}


### PR DESCRIPTION
If the player tries to place a Grill where it is not allowed, the Grill block is not added to the world
but the item is deleted from the players inventory (some conditions).
I also moved the first checkSides to the inner 'if' since it is not relevant for the second 'if'.

Fix for http://terrafirmacraft.com/f/topic/7078-grill-deletion-bug-re-fueling-confusion/#entry94893
but I also came across this last night when trying to figure out how to use a Grill...

Something to think about: should the conditions to place a Grill also be
checked after it was placed, that is, should the Grill be dropped if one
of the blocks needed to place it is removed?
