### PR TITLE
clear the AnvilManager's recipe lists when adding new ones

### DIFF
--- a/src/Common/com/bioxx/tfc/Core/Recipes.java
+++ b/src/Common/com/bioxx/tfc/Core/Recipes.java
@@ -1582,6 +1582,10 @@ public class Recipes
 	{
 		AnvilManager manager = AnvilManager.getInstance();
 
+        manager.getRecipeList().clear();
+        manager.getWeldRecipeList().clear();
+        manager.getPlans().clear();
+
 		manager.addPlan("ingot", new PlanRecipe(
 				new RuleEnum[] {RuleEnum.HITLAST, RuleEnum.HITSECONDFROMLAST, RuleEnum.HITTHIRDFROMLAST}));
 		manager.addPlan("sheet", new PlanRecipe(


### PR DESCRIPTION
clear the AnvilManager's recipe lists when adding new ones. Otherwise the adding doesn't have any effect.

Found because recipes where showing up twice (or more) in NEI
