### PR TITLE
Treat ore as Raw Stone when determining if a block can be chiseled.

### DIFF
--- a/src/Common/com/bioxx/tfc/Core/TFC_Core.java
+++ b/src/Common/com/bioxx/tfc/Core/TFC_Core.java
@@ -309,6 +309,18 @@ public class TFC_Core
 				|| block == TFCBlocks.StoneMM;
 	}
 
+	public static boolean isOreStone(Block block)
+	{
+		return block == TFCBlocks.Ore
+				|| block == TFCBlocks.Ore2
+				|| block == TFCBlocks.Ore3;
+	}
+
+	public static boolean isNaturalStone(Block block)
+	{
+		return isRawStone( block ) || isOreStone( block );
+	}
+	
 	public static boolean isCobbleStone(Block block)
 	{
 		return block == TFCBlocks.StoneIgExCobble

--- a/src/Common/com/bioxx/tfc/Items/Tools/ItemChisel.java
+++ b/src/Common/com/bioxx/tfc/Items/Tools/ItemChisel.java
@@ -320,7 +320,7 @@ public class ItemChisel extends ItemTerraTool implements IToolChisel
 		{
 			if(mode == 0)
 			{
-				if(TFC_Core.isRawStone(world.getBlock(x, y+1, z)) && TFC_Core.isRawStone(world.getBlock(x, y+2, z))) {
+				if(TFC_Core.isNaturalStone(world.getBlock(x, y+1, z)) && TFC_Core.isNaturalStone(world.getBlock(x, y+2, z))) {
 					return false;
 				}
 
@@ -332,8 +332,8 @@ public class ItemChisel extends ItemTerraTool implements IToolChisel
 			}
 			else if(mode == 1)
 			{
-				if (TFC_Core.isRawStone(block) && TFC_Core.isRawStone(world.getBlock(x, y+1, z)) && 
-						TFC_Core.isRawStone(world.getBlock(x, y+2, z))) {
+				if (TFC_Core.isNaturalStone(block) && TFC_Core.isNaturalStone(world.getBlock(x, y+1, z)) && 
+						TFC_Core.isNaturalStone(world.getBlock(x, y+2, z))) {
 					return false;
 				}
 
@@ -345,8 +345,8 @@ public class ItemChisel extends ItemTerraTool implements IToolChisel
 			}
 			else if(mode == 2)
 			{
-				if (TFC_Core.isRawStone(block) && TFC_Core.isRawStone(world.getBlock(x, y+1, z)) && 
-						TFC_Core.isRawStone(world.getBlock(x, y+2, z))) {
+				if (TFC_Core.isNaturalStone(block) && TFC_Core.isNaturalStone(world.getBlock(x, y+1, z)) && 
+						TFC_Core.isNaturalStone(world.getBlock(x, y+2, z))) {
 					return false;
 				}
 


### PR DESCRIPTION
Continues https://github.com/Deadrik/TFCraft/commit/8516e00db15421cd64a3c8dd870842a512cef191 by also blacklisting ores.

Based on: http://terrafirmacraft.com/f/topic/7144-0799-chisel-issue/
