### PR TITLE
according to the WIKI rainfall must be at least 500 for fruit trees

### DIFF
--- a/src/Common/com/bioxx/tfc/WorldGen/Generators/WorldGenPlants.java
+++ b/src/Common/com/bioxx/tfc/WorldGen/Generators/WorldGenPlants.java
@@ -154,7 +154,7 @@ public class WorldGenPlants implements IWorldGenerator
 			}
 		}
 
-		if (random.nextInt(70) == 0 && rain > 500)
+		if (random.nextInt(70) == 0 && rain >= 500)
 		{
 			xCoord = chunkX + random.nextInt(16) + 8;
 			zCoord = chunkZ + random.nextInt(16) + 8;


### PR DESCRIPTION
minimal... but seems to be a problem: http://terrafirmacraft.com/f/topic/7168-no-fruit-trees-at-all/

but there is still the question if it would be better to change the WIKI and leave the code as is (eventually adjusting WorldGenCustomFruitTree where it actually is ">= 500")?
