### PR TITLE
Stopped players in creative from being overburdened

### DIFF
--- a/src/Common/com/bioxx/tfc/Handlers/EntityLivingHandler.java
+++ b/src/Common/com/bioxx/tfc/Handlers/EntityLivingHandler.java
@@ -104,14 +104,17 @@ public class EntityLivingHandler
 
 				//Scan the players inventory for any items that are too heavy to carry normally
 				boolean isOverburdened = false;
-				for (int i = 0; i < player.inventory.mainInventory.length;i++)
+				if(!player.capabilities.isCreativeMode)
 				{
-					ItemStack is = player.inventory.getStackInSlot(i);
-					if(is != null && is.getItem() instanceof IEquipable)
+					for (int i = 0; i < player.inventory.mainInventory.length;i++)
 					{
-						isOverburdened = ((IEquipable)is.getItem()).getTooHeavyToCarry(is);
-						if(isOverburdened)
-							break;
+						ItemStack is = player.inventory.getStackInSlot(i);
+						if(is != null && is.getItem() instanceof IEquipable)
+						{
+							isOverburdened = ((IEquipable)is.getItem()).getTooHeavyToCarry(is);
+							if(isOverburdened)
+								break;
+						}
 					}
 				}
 


### PR DESCRIPTION
Stopped players in creative mode from becoming overburdened when
carrying items too heavy to carry in survival.
