### PR TITLE
Fixed being able to fill unfired large vessels with water

### DIFF
--- a/src/Common/com/bioxx/tfc/Blocks/Devices/BlockBarrel.java
+++ b/src/Common/com/bioxx/tfc/Blocks/Devices/BlockBarrel.java
@@ -410,6 +410,9 @@ public class BlockBarrel extends BlockTerraContainer
 						}
 						else if(is.getItem() instanceof ItemLargeVessel)
 						{
+							if(is.getItemDamage() == 0)
+								return false;
+							
 							FluidStack fs = te.getFluidStack().copy();
 							if(fs.amount > 5000)
 							{

--- a/src/Common/com/bioxx/tfc/Items/ItemBlocks/ItemLargeVessel.java
+++ b/src/Common/com/bioxx/tfc/Items/ItemBlocks/ItemLargeVessel.java
@@ -133,7 +133,7 @@ public class ItemLargeVessel extends ItemTerraBlock implements IEquipable
 				int j = mop.blockY;
 				int k = mop.blockZ;
 
-				if (!player.canPlayerEdit(i, j, k, mop.sideHit, is) || !(world.getBlock(i, j, k) instanceof IFluidBlock) || is.hasTagCompound())
+				if (!player.canPlayerEdit(i, j, k, mop.sideHit, is) || !(world.getBlock(i, j, k) instanceof IFluidBlock) || is.hasTagCompound() || is.getItemDamage() == 0)
 				{
 					return super.onItemUse(is, player, world, x, y, z, side, hitX, hitY, hitZ);
 				}


### PR DESCRIPTION
Stopped players being able to fill unfired large vessels from water blocks or placed containers.
