### PR TITLE
Small Pottery Vessel Tooltip showing Number of Units

### DIFF
--- a/src/Common/com/bioxx/tfc/Items/Pottery/ItemPotterySmallVessel.java
+++ b/src/Common/com/bioxx/tfc/Items/Pottery/ItemPotterySmallVessel.java
@@ -294,7 +294,7 @@ public class ItemPotterySmallVessel extends ItemPotteryBase implements IBag
 				if(tag.hasKey("MetalAmount"))
 				{
 					// suffix the amount of metal to the metal name.
-					name += " (" + tag.getInteger("MetalAmount")+StatCollector.translateToLocal("gui.units");
+					name += " (" + tag.getInteger("MetalAmount")+" "+StatCollector.translateToLocal("gui.units")+")";
 				}
 
 				arraylist.add(EnumChatFormatting.DARK_GREEN + name);


### PR DESCRIPTION
Added a suffix to the metal name with the number of units contained
within the small vessel to the tooltip. This is useful when the metal
has solidified and the player cannot open the vessel.
