### PR TITLE
add Flint&Steel Firestarter and Rope in the ToolRack

### DIFF
--- a/src/Common/com/bioxx/tfc/Blocks/Devices/BlockToolRack.java
+++ b/src/Common/com/bioxx/tfc/Blocks/Devices/BlockToolRack.java
@@ -161,7 +161,7 @@ public class BlockToolRack extends BlockTerraContainer
 		if(te.storage[slot] == null && hasToolInHand)
 		{
 			te.storage[slot] = entityplayer.getCurrentEquippedItem().copy();
-			entityplayer.inventory.mainInventory[entityplayer.inventory.currentItem] = null;
+			entityplayer.getCurrentEquippedItem().stackSize--;
 		}
 		else if(te.storage[slot] != null)
 		{


### PR DESCRIPTION
Because these are tools that we often need to take or store.
And often in the same place.

![capture du 2014-11-04 20 14 22](https://cloud.githubusercontent.com/assets/401965/4906433/debc7876-6458-11e4-902f-200764f25d03.png)
