### PR TITLE
Centering the ingot texture

### DIFF
--- a/src/Common/com/bioxx/tfc/Render/Models/ModelIngot.java
+++ b/src/Common/com/bioxx/tfc/Render/Models/ModelIngot.java
@@ -18,22 +18,18 @@ public class ModelIngot extends ModelBox
     /** An array of 6 TexturedQuads, one for each face of a cube */
     private TexturedQuad[] quadList;
 	
-	public ModelIngot(ModelRenderer renderer, int textureOffsetX, int textureOffsetY,
-			float originX, float originY, float originZ, int width, int height, int depth,
-			float scale) {
-		super(renderer, textureOffsetX, textureOffsetY, originX, originY, originZ, width, height, depth, scale);
+	public ModelIngot(ModelRenderer renderer, int textureOffsetX, int textureOffsetY) {
+		super(renderer, textureOffsetX, textureOffsetY, 0.5F, 0, 0.5F, 15, 4, 7, 0);
+		
+		float originX = .5f;
+		float originY = 0;
+		float originZ = .5f;
 		
         this.vertexPositions = new PositionTextureVertex[8];
         this.quadList = new TexturedQuad[6];
-        float maxX = originX + (float)width;
-        float maxY = originY + (float)height;
-        float maxZ = originZ + (float)depth;
-        originX -= scale;
-        originY -= scale;
-        originZ -= scale;
-        maxX += scale;
-        maxY += scale;
-        maxZ += scale;
+        float maxX = originX + 15;
+        float maxY = originY + 4;
+        float maxZ = originZ + 7;
         
         PositionTextureVertex vert0 = new PositionTextureVertex(originX, originY, originZ, 0.0F, 0.0F);
         PositionTextureVertex vert1 = new PositionTextureVertex(maxX, originY, originZ, 0.0F, 8.0F);
@@ -52,40 +48,29 @@ public class ModelIngot extends ModelBox
         this.vertexPositions[6] = vert6;
         this.vertexPositions[7] = vert7;
         
-        int x1 = textureOffsetX + 8;
-        int x2 = textureOffsetX + 16;
-        int x3 = textureOffsetX + 32;
-        int x5 = textureOffsetX + 48;
-        
+        int x1 = textureOffsetX + 4;
+        int x2 = textureOffsetX + 20;
+        int x3 = textureOffsetX + 44;
+        int x4 = textureOffsetX + 60;
+            
         int y1 = textureOffsetY + 4;
         int y2 = textureOffsetY + 8;
-        int y3 = textureOffsetY + 24;
-        int y4 = textureOffsetY + 28;
-        
-        if( width > depth ) {
-            x1 = textureOffsetX + 8;
-            x2 = textureOffsetX + 16;
-            x3 = textureOffsetX + 48;
-            x5 = textureOffsetX + 32;
-            
-            y1 = textureOffsetY + 4;
-            y2 = textureOffsetY + 8;
-            y3 = textureOffsetY + 16;
-            y4 = textureOffsetY + 20;
-        }
+        int y3 = textureOffsetY + 16;
+        int y4 = textureOffsetY + 20;
+        int y5 = textureOffsetY + 28;
         
         this.quadList[0] = new TexturedQuad(new PositionTextureVertex[] {vert5, vert1, vert2, vert6}, 
-        		x5, y3, x2, y4, renderer.textureWidth, renderer.textureHeight);
+        		x3, y1, x4, y2, renderer.textureWidth, renderer.textureHeight); // petit
         this.quadList[1] = new TexturedQuad(new PositionTextureVertex[] {vert0, vert4, vert7, vert3}, 
-        		x5, y1, x2, y2, renderer.textureWidth, renderer.textureHeight);
+        		x1, y1, x2, y2, renderer.textureWidth, renderer.textureHeight); // petit
         this.quadList[2] = new TexturedQuad(new PositionTextureVertex[] {vert5, vert4, vert0, vert1}, 
-        		x1, y3, x2, y2, renderer.textureWidth, renderer.textureHeight);
+        		x2, y4, x3, y5, renderer.textureWidth, renderer.textureHeight); // bottom
         this.quadList[3] = new TexturedQuad(new PositionTextureVertex[] {vert2, vert3, vert7, vert6}, 
-        		x2, y2, x3, y3, renderer.textureWidth, renderer.textureHeight);
+        		x2, y2, x3, y3, renderer.textureWidth, renderer.textureHeight); // top
         this.quadList[4] = new TexturedQuad(new PositionTextureVertex[] {vert1, vert0, vert3, vert2}, 
-        		x2, y1, x3, y2, renderer.textureWidth, renderer.textureHeight);
+        		x2, y1, x3, y2, renderer.textureWidth, renderer.textureHeight); // long
         this.quadList[5] = new TexturedQuad(new PositionTextureVertex[] {vert4, vert5, vert6, vert7}, 
-        		x2, y4, x3, y3, renderer.textureWidth, renderer.textureHeight);
+        		x3, y4, x2, y3, renderer.textureWidth, renderer.textureHeight); // long
 	}
 	
 	@SideOnly(Side.CLIENT)

--- a/src/Common/com/bioxx/tfc/Render/Models/ModelIngotPile.java
+++ b/src/Common/com/bioxx/tfc/Render/Models/ModelIngotPile.java
@@ -8,46 +8,27 @@ import cpw.mods.fml.relauncher.SideOnly;
 public class ModelIngotPile extends ModelBase
 {
 	public ModelRendererTFC[] renderer = new ModelRendererTFC[64];
-	int ingotHeight = 4;
-	int ingotWidth = 7;
-	int ingotDepth = 15;
 
 	public ModelIngotPile()
 	{
 		for (int n = 0; n < 64; n++){
 			this.renderer[n] = new ModelRendererTFC(this,0,0);
 			int m = (n+8)/8;
-			float x = (n %4)*8f;
-			float y = (m -1)*4f;
+			float x = (n %4)*0.25f;
+			float y = (m -1)*0.125f;
 			float z = 0;
 
-
-			if (n%8 >=4){
-				z = 16f;
-			}
-			if (m %2 == 1)
-			{
-				renderer[n].cubeList.add(
-						new ModelIngot(renderer[n],renderer[n].textureOffsetX, renderer[n].textureOffsetY, 0.5F + x, y, z + 0.5f, ingotWidth, ingotHeight, ingotDepth, 0f));
-
-				/*Object[] dataArray = new Object[10];
-				dataArray[0] = new float[] {0,0,0,8,0,8,8};
-				dataArray[9] = new float[] {0,0,0,8,1,8,5};
-				dataArray[1] = new float[] {0,0,0,8,4,8,13};
-				dataArray[8] = new float[] {0,0,0,8,4,8,9};
-				dataArray[2] = new float[] {0,0,0,8,11,8,12};
-				dataArray[7] = new float[] {0,0,0,8,11,8,9};
-				dataArray[3] = new float[] {0,0,0,8,13,8,8};
-				dataArray[6] = new float[] {0,0,0,8,13,8,5};
-				dataArray[4] = new float[] {0,0,0,8,15,8,8};
-				dataArray[5] = new float[] {0,0,0,8,15,8,5};
-				renderer[n].cubeList.add(new ModelPotteryBase(renderer[n],renderer[n].textureOffsetX, renderer[n].textureOffsetY, 0.5F + x, y, z + 0.5f, ingotWidth, ingotHeight, ingotDepth, 0f,dataArray,true));*/
-			}
-			else
-			{
-				renderer[n].cubeList.add(
-						new ModelIngot(renderer[n],renderer[n].textureOffsetX, renderer[n].textureOffsetY, z + 0.5f, y, 0.5f + x, ingotDepth, ingotHeight, ingotWidth, 0f));
-				
+			if (n%8 >=4) z = .5F;
+			
+			renderer[n].cubeList.add(new ModelIngot(renderer[n],renderer[n].textureOffsetX, renderer[n].textureOffsetY));
+			renderer[n].offsetY = y;
+			if (m %2 == 1) {
+				renderer[n].rotateAngleY = 1.56F;
+				renderer[n].offsetX = x;
+				renderer[n].offsetZ = z+.5F;
+			} else {
+				renderer[n].offsetX = z;
+				renderer[n].offsetZ = x;
 			}
 		}
 	}


### PR DESCRIPTION
Problem :
This is not obvious, but ingotPile are oddly textured. 

The mapping is different for each layer. 
lvl1, lvl3, lvl5, lvl7 ---------------------------- lvl2, lvl4, lvl6, lvl8
![lvl1](https://cloud.githubusercontent.com/assets/401965/4927821/d5109be0-653e-11e4-8e0c-50adebcab591.png) ![lvl2](https://cloud.githubusercontent.com/assets/401965/4927823/d6c364c2-653e-11e4-8884-b55af7ffce78.png)

Therefore, it is difficult to adapt the texture for have effect on the ingots. 

---

One solution :

provided with this pull request :

One mapping for all.
![lvl1 2](https://cloud.githubusercontent.com/assets/401965/4928009/86d73cde-6540-11e4-8895-1c59dd01fe5e.png)

Avantage :
- One mapping for all ingots.
- Snap to pixel grid.
- Pixel (almost) square when rendering.
- Free edge.
