### PR TITLE
Detailed Block now has solid sides

### DIFF
--- a/src/API/com/bioxx/tfc/api/TFCOptions.java
+++ b/src/API/com/bioxx/tfc/api/TFCOptions.java
@@ -12,7 +12,7 @@ public class TFCOptions
 	public static boolean use2DGrill;
 	public static boolean generateSmoke;
 	public static boolean enableDetailedBlockSolidSide;
-	public static double detailedBlockSolidSidePercentage;
+	public static int maxCountOfTranspSubBlocksOnSide;
 
 	public static boolean enableCropsDie;
 

--- a/src/Common/com/bioxx/tfc/Blocks/BlockDetailed.java
+++ b/src/Common/com/bioxx/tfc/Blocks/BlockDetailed.java
@@ -4,8 +4,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.bioxx.tfc.api.TFCOptions;
+import ibxm.Player;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.particle.EffectRenderer;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.Entity;
@@ -99,52 +101,29 @@ public class BlockDetailed extends BlockPartial
 	{
 		if (!TFCOptions.enableDetailedBlockSolidSide)
 			return false;
+		if (side == ForgeDirection.UNKNOWN)
+			return false;
+
+		int transpCount = TFCOptions.maxCountOfTranspSubBlocksOnSide;
+		if (transpCount < 0 || transpCount >= 64)
+			return false;
 
 		TEDetailed te = (TEDetailed) world.getTileEntity(x, y, z);
 
-		int tranCount = 64 - TFCOptions.minCountOfSolidSubBlocksOnSide;
-		switch (side)
-		{
-			case UP:
-				for (int sub_z = 0; sub_z < 8; ++sub_z)
-					for (int sub_x = 0; sub_x < 8; ++sub_x)
-						if (!te.getBlockExists(sub_x, 7, sub_z) && --tranCount < 0)
-							return false;
-				break;
-			case DOWN:
-				for (int sub_z = 0; sub_z < 8; ++sub_z)
-					for (int sub_x = 0; sub_x < 8; ++sub_x)
-						if (te.getBlockExists(sub_x, 0, sub_z) && --tranCount < 0)
-							return false;
-				break;
-			case NORTH:
-				for (int sub_x = 0; sub_x < 8; ++sub_x)
-					for (int sub_y = 0; sub_y < 8; ++sub_y)
-						if (te.getBlockExists(sub_x, sub_y, 0) && --tranCount < 0)
-							return false;
-				break;
-			case SOUTH:
-				for (int sub_x = 0; sub_x < 8; ++sub_x)
-					for (int sub_y = 0; sub_y < 8; ++sub_y)
-						if (te.getBlockExists(sub_x, sub_y, 7) && --tranCount < 0)
-							return false;
-				break;
-			case WEST:
-				for (int sub_z = 0; sub_z < 8; ++sub_z)
-					for (int sub_y = 0; sub_y < 8; ++sub_y)
-						if (te.getBlockExists(0, sub_y, sub_z) && --tranCount < 0)
-							return false;
-				break;
-			case EAST:
-				for (int sub_z = 0; sub_z < 8; ++sub_z)
-					for (int sub_y = 0; sub_y < 8; ++sub_y)
-						if (te.getBlockExists(7, sub_y, sub_z) && --tranCount < 0)
-							return false;
-				break;
-			case UNKNOWN:
-			default:
-				return false;
-		}
+		int start_x = (side == ForgeDirection.EAST ? 7 : 0);
+		int end_x = (side == ForgeDirection.WEST ? 1 : 8);
+
+		int start_y = (side == ForgeDirection.UP ? 7 : 0);
+		int end_y = (side == ForgeDirection.DOWN ? 1 : 8);
+
+		int start_z = (side == ForgeDirection.SOUTH ? 7 : 0);
+		int end_z = (side == ForgeDirection.NORTH ? 1 : 8);
+
+		for (int sub_x = start_x; sub_x < end_x; ++sub_x)
+			for (int sub_y = start_y; sub_y < end_y; ++sub_y)
+				for (int sub_z = start_z; sub_z < end_z; ++sub_z)
+					if (!te.getBlockExists(sub_x, sub_y, sub_z) && --transpCount < 0)
+						return false;
 
 		return true;
 	}

--- a/src/Common/com/bioxx/tfc/TerraFirmaCraft.java
+++ b/src/Common/com/bioxx/tfc/TerraFirmaCraft.java
@@ -304,7 +304,7 @@ public class TerraFirmaCraft
 		TFCOptions.quiverHUDPosition = TFCOptions.getStringFor(config, "General", "quiverHUDPosition", "bottomleft", "Valid position strings are: bottomleft, left, topleft, bottomright, right, topright");
 		TFCOptions.generateSmoke = TFCOptions.getBooleanFor(config, "General", "generateSmoke", false, "Should forges generate smoke blocks? *Caution Unsupported*");
 		TFCOptions.enableDetailedBlockSolidSide = TFCOptions.getBooleanFor(config, "General", "enableDetailedBlockSolidSide", true, "Should sides of Detailed blocks be considered as solid?");
-		TFCOptions.detailedBlockSolidSidePercentage = TFCOptions.getDoubleFor(config, "General", "detailedBlockSolidSidePercentage", 90.0, "Percentage of opaque sub-blocks on the side");
+		TFCOptions.maxCountOfTranspSubBlocksOnSide = TFCOptions.getIntFor(config, "General", "maxCountOfTranspSubBlocksOnSide", 12, "Maximum count of transparent sub-blocks on side: 0..64");
 
 		//Time
 		TFCOptions.yearLength = TFCOptions.getIntFor(config, "Time", "yearLength", 96, "This is how many days are in a year. Keep this to multiples of 12.");


### PR DESCRIPTION
Make sides of the detailed block solid, If the count of transparent sub-blocks on the side is less than 12.
Default value are calculated on this kind of tables:
00111100
01111110
11111111
11111111
11111111
11111111
01111110
00111100
Count can be changed in config file.

PS. This just implements method isSideSolid() for BlockDetailed class.

PSS. The main reason for writing this in the use of detailed blocks for cooking meals.

PSSS. I've been requested this already earlier, but I had to redesign my repository, and rebase some branches. So I closed previous request and start this from new branch. [Link to previous request](https://github.com/Deadrik/TFCraft/pull/667).
