### PR TITLE
Rain (really) put torches off, allow lit torches to be "recharged"

### DIFF
--- a/src/Common/com/bioxx/tfc/Blocks/Vanilla/BlockTorch.java
+++ b/src/Common/com/bioxx/tfc/Blocks/Vanilla/BlockTorch.java
@@ -83,13 +83,24 @@ public class BlockTorch extends BlockTerraContainer
 				player.inventory.consumeInventoryItem(TFCItems.Stick);
 				TFC_Core.giveItemToPlayer(new ItemStack(TFCBlocks.Torch), player);
 			}
-			else if(world.getBlockMetadata(x, y, z) >= 8 && player.inventory.getCurrentItem() != null && 
+			else if(player.inventory.getCurrentItem() != null && 
 					player.inventory.getCurrentItem().getItem() == Item.getItemFromBlock(TFCBlocks.Torch))
 			{
 				TELightEmitter te = (TELightEmitter)world.getTileEntity(x, y, z);
 				te.hourPlaced = (int)TFC_Time.getTotalHours();
-				world.setBlockMetadataWithNotify(x, y, z, world.getBlockMetadata(x, y, z)-8, 3);
+				if (world.getBlockMetadata(x, y, z) >= 8)
+				{
+				    world.setBlockMetadataWithNotify(x, y, z, world.getBlockMetadata(x, y, z)-8, 3);
+				}
 			}
+		}
+		else
+		{
+		    if(TFCOptions.enableDebugMode)
+		    {
+		        int metadata = world.getBlockMetadata(x, y, z);
+		        System.out.println("Meta = "+(new StringBuilder()).append(getUnlocalizedName()).append(":").append(metadata).toString());
+		    }
 		}
 		return true;
 	}


### PR DESCRIPTION
- Torches are now put off by rain when under open sky and burnout is enabled.
  I hope that is how it really was intended, not as it was before, that is,
  torches were only affected by rain if the burnout was disabled BurnTime zero).
- Lit torches can be "recharged", not only the burnout ones. …
  The burnout timer is always reset when right-clicking with a lit torch, no matter if the torch is burned out or not.
