### PR TITLE
Fix accumulate snow

### DIFF
--- a/src/Common/com/bioxx/tfc/WorldGen/TFCProvider.java
+++ b/src/Common/com/bioxx/tfc/WorldGen/TFCProvider.java
@@ -187,14 +187,14 @@ public class TFCProvider extends WorldProvider
 	@Override
 	public boolean canSnowAt(int x, int y, int z, boolean checkLight)
 	{
-        if (TFC_Climate.getHeightAdjustedTemp(worldObj,x, y, z) > 0)
-	        return false;
-        Material material = worldObj.getBlock(x, y, z).getMaterial();
-        if (material == Material.snow)  // avoid vanilla MC to replace snow
-            return false;
+		if (TFC_Climate.getHeightAdjustedTemp(worldObj,x, y, z) > 0)
+			return false;
+		Material material = worldObj.getBlock(x, y, z).getMaterial();
+		if (material == Material.snow)  // avoid vanilla MC to replace snow
+			return false;
 		if(TFCBlocks.Snow.canPlaceBlockAt(worldObj, x, y, z) && material.isReplaceable())
 			return true;
-		
+
 		return false;
 	}
 


### PR DESCRIPTION
TFCProvider.canSnowAt(): Don't allow snowing 'in' a snow block to avoid having vanilla MC create a new snow block if there is already one there.
http://terrafirmacraft.com/f/topic/7080-remove-snow-accumulation-limit/

BlockCustomSnow:
- equalized number of layers: minimum is zero (1 layer), maximum is 7 (8 layers)
- always mask meta wiht 7 (meta & 7)
- renamed some variables, removed unused variables.
- restructured updateTick() so it is (hopefully) easier to understand

Still open:
- speed reduction is a bit 'digital', maybe intentional:
  1 layer = no speed lost;
  2 layers = 2% slower;
  3 or more = 42% slower
- canAddSnowCheckNeighbors is not working very well IMHO:
  if I have a block (1 high) on a flat plain, snow will
  accumulate on its top, but not on its base
- Configurations to tweak snow generation speed
