### PR TITLE
Fixed the TFC bow recipe

### DIFF
--- a/src/Common/com/bioxx/tfc/TFCItems.java
+++ b/src/Common/com/bioxx/tfc/TFCItems.java
@@ -1021,7 +1021,7 @@ public class TFCItems
 		Coal = new ItemCoal().setUnlocalizedName("coal");
 		Stick = new ItemStick().setFull3D().setUnlocalizedName("stick");
 		Bow = new ItemCustomBow().setUnlocalizedName("bow").setTextureName("bow");
-		Items.bow = (ItemBow) Bow;
+		//Items.bow = (ItemBow) Bow;
 		Arrow = new ItemArrow().setUnlocalizedName("arrow").setCreativeTab(TFCTabs.TFCWeapons);
 		Dye = new ItemDyeCustom().setUnlocalizedName("dyePowder").setTextureName("dye_powder").setCreativeTab(TFCTabs.TFCMaterials);
 		GlassBottle = new ItemGlassBottle().setUnlocalizedName("Glass Bottle");


### PR DESCRIPTION
Fixed TFC bow recipe, the line in Setup() was setting the vanilla bow
to the TFC bow so when vanilla recipes later get removed it tries to
remove the TFC recipe (which doesn't exist yet) instead of the vanilla
one.
