### PR TITLE
fix spawn protection not being correctly loaded/saved.

### DIFF
--- a/src/Common/com/bioxx/tfc/Commands/GSPVisualCommand.java
+++ b/src/Common/com/bioxx/tfc/Commands/GSPVisualCommand.java
@@ -41,7 +41,7 @@ public class GSPVisualCommand extends CommandBase{
 			for(int x = 0; x < 16; x++)
 			{
 				for(int z = 0; z < 16; z++)
-					world.setBlock(x+(chunk.xPosition*16), (int)player.posY-1, z+(chunk.zPosition*16), Blocks.wool, getColor(d.spawnProtection), 2);
+					world.setBlock(x+(chunk.xPosition*16), (int)player.posY-1, z+(chunk.zPosition*16), Blocks.wool, getColor(d.getSpawnProtectionWithUpdate()), 2);
 			}
 		}
 		else if(params.length == 1)
@@ -55,7 +55,7 @@ public class GSPVisualCommand extends CommandBase{
 					for(int x = 0; x < 16; x++)
 					{
 						for(int z = 0; z < 16; z++)
-							world.setBlock(x + (chunk.xPosition * 16), (int)player.posY - 1, z + (chunk.zPosition * 16), Blocks.wool, getColor(d.spawnProtection), 2);
+							world.setBlock(x + (chunk.xPosition * 16), (int)player.posY - 1, z + (chunk.zPosition * 16), Blocks.wool, getColor(d.getSpawnProtectionWithUpdate()), 2);
 					}
 				}
 			}

--- a/src/Common/com/bioxx/tfc/Commands/GetSpawnProtectionCommand.java
+++ b/src/Common/com/bioxx/tfc/Commands/GetSpawnProtectionCommand.java
@@ -3,6 +3,7 @@ package com.bioxx.tfc.Commands;
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.command.PlayerNotFoundException;
+import net.minecraft.command.WrongUsageException;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.server.MinecraftServer;
 
@@ -21,18 +22,32 @@ public class GetSpawnProtectionCommand extends CommandBase{
 	{
 		if(sender.canCommandSenderUseCommand(0, sender.getCommandSenderName()))
 		{
-			MinecraftServer var3 = MinecraftServer.getServer();
-			EntityPlayerMP var4;
+			EntityPlayerMP player = getCommandSenderAsPlayer(sender);
 
-			var4 = getCommandSenderAsPlayer(sender);
+			int x;
+			int z;
+			if (params.length >= 2)
+			{
+				try
+				{
+					x = Integer.parseInt(params[0]);
+					z = Integer.parseInt(params[1]);
+				} 
+				catch (NumberFormatException ex)
+				{
+					throw new WrongUsageException("invalid chunk coords: %d x %d", params[0], params[1]);
+				}
+			}
+			else
+			{
+				x = (int)player.posX >> 4;
+				z = (int)player.posZ >> 4;				
+			}
 
-			int x = (int)var4.posX >> 4;
-			int z = (int)var4.posZ >> 4;
-
-			ChunkData d = TFC_Core.getCDM(var4.worldObj).getData(x, z);
+			ChunkData d = TFC_Core.getCDM(player.worldObj).getData(x, z);
 
 			if(d != null)
-				throw new PlayerNotFoundException("SP: " + d.getSpawnProtectionWithUpdate());
+				throw new PlayerNotFoundException("SP (" + x + "," + z + "): " + d.getSpawnProtectionWithUpdate());
 			else
 				throw new PlayerNotFoundException("Unable to find ChunkData for "+x+","+z);
 		}

--- a/src/Common/com/bioxx/tfc/Handlers/ChunkEventHandler.java
+++ b/src/Common/com/bioxx/tfc/Handlers/ChunkEventHandler.java
@@ -8,6 +8,7 @@ import net.minecraft.util.ChunkCoordinates;
 import net.minecraft.world.ChunkPosition;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
+import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.storage.WorldInfo;
 import net.minecraftforge.event.world.ChunkDataEvent;
 import net.minecraftforge.event.world.ChunkEvent;
@@ -83,9 +84,10 @@ public class ChunkEventHandler
 		}
 		else
 		{
-			ChunkData data = new ChunkData().CreateNew(event.world, event.getChunk().xPosition, event.getChunk().zPosition);
+			Chunk chunk = event.getChunk();
+			ChunkData data = new ChunkData(chunk).CreateNew(event.world, chunk.xPosition, chunk.zPosition);
 			data.rainfallMap = TFC_Climate.getCacheManager(event.world).loadRainfallLayerGeneratorData(data.rainfallMap, event.getChunk().xPosition * 16, event.getChunk().zPosition * 16, 16, 16);
-			TFC_Core.getCDM(event.world).addData(event.getChunk(), data);
+			TFC_Core.getCDM(event.world).addData(chunk, data);
 		}
 	}
 
@@ -126,19 +128,20 @@ public class ChunkEventHandler
 		{
 			NBTTagCompound eventTag = event.getData();
 
+			Chunk chunk = event.getChunk();
 			if(eventTag.hasKey("ChunkData"))
 			{
 				NBTTagCompound spawnProtectionTag = eventTag.getCompoundTag("ChunkData");
-				ChunkData data = new ChunkData(spawnProtectionTag);
-				TFC_Core.getCDM(event.world).addData(event.getChunk(), data);
+				ChunkData data = new ChunkData(chunk, spawnProtectionTag);
+				TFC_Core.getCDM(event.world).addData(chunk, data);
 			}
 			else
 			{
 				/*if(TFC_Core.getCDM(event.world).hasData(event.getChunk()))
 					return;*/
 				NBTTagCompound levelTag = eventTag.getCompoundTag("Level");
-				ChunkData data = new ChunkData().CreateNew(event.world, levelTag.getInteger("xPos"), levelTag.getInteger("zPos"));
-				TFC_Core.getCDM(event.world).addData(event.getChunk(), data);
+				ChunkData data = new ChunkData(chunk).CreateNew(event.world, levelTag.getInteger("xPos"), levelTag.getInteger("zPos"));
+				TFC_Core.getCDM(event.world).addData(chunk, data);
 			}
 		}
 	}

--- a/src/Common/com/bioxx/tfc/WorldGen/TFCChunkProviderGenerate.java
+++ b/src/Common/com/bioxx/tfc/WorldGen/TFCChunkProviderGenerate.java
@@ -180,7 +180,7 @@ public class TFCChunkProviderGenerate extends ChunkProviderGenerate
 			}
 		}
 
-		ChunkData data = new ChunkData().CreateNew(worldObj, chunkX, chunkZ);
+		ChunkData data = new ChunkData(chunk).CreateNew(worldObj, chunkX, chunkZ);
 		data.heightmap = seaLevelOffsetMap;
 		data.rainfallMap = this.rainfallLayer;
 		TFC_Core.getCDM(worldObj).addData(chunk, data);


### PR DESCRIPTION
- mark Chunk as modified when spawn protection is changed
- avoid integer division rounding error
- create one private method to update spawn protection
- changed GSP command to allow entering chunk coordinates

point 2 of http://terrafirmacraft.com/f/topic/7089-spawn-protection-bugs/#entry94989
