### PR TITLE
Allow torches to be extinguished if right clicked without a torch/stick in hand.

### DIFF
--- a/src/Common/com/bioxx/tfc/Blocks/Vanilla/BlockTorch.java
+++ b/src/Common/com/bioxx/tfc/Blocks/Vanilla/BlockTorch.java
@@ -93,6 +93,10 @@ public class BlockTorch extends BlockTerraContainer
 				    world.setBlockMetadataWithNotify(x, y, z, world.getBlockMetadata(x, y, z)-8, 3);
 				}
 			}
+			else if (world.getBlockMetadata(x, y, z) < 8)
+			{
+				world.setBlockMetadataWithNotify(x, y, z, world.getBlockMetadata(x, y, z)+8, 3);
+			}
 		}
 		else
 		{


### PR DESCRIPTION
This change will allow torches to be extinguished manually. Useful for a food cellar.
