### PR TITLE
Food Infusion Fix

### DIFF
--- a/src/API/com/bioxx/tfc/api/Food.java
+++ b/src/API/com/bioxx/tfc/api/Food.java
@@ -316,6 +316,12 @@ public class Food
 		return profile;
 	}
 
+	public static String getInfusion(ItemStack is)
+	{
+		NBTTagCompound nbt = getProcTag(is);
+		return nbt.getString("Infusion");
+	}
+
 	public static boolean isInfused(ItemStack is)
 	{
 		NBTTagCompound nbt = getProcTag(is);

--- a/src/Common/com/bioxx/tfc/Food/ItemFoodTFC.java
+++ b/src/Common/com/bioxx/tfc/Food/ItemFoodTFC.java
@@ -194,8 +194,8 @@ public class ItemFoodTFC extends ItemTerra implements ISize, ICookableFood, IMer
 
 		if(Food.isDried(is) && !Food.isCooked(is))
 			s += StatCollector.translateToLocal("word.dried") + " ";
-		if(is.getTagCompound().hasKey("Infusion"))
-			s += StatCollector.translateToLocal(is.getTagCompound().getString("Infusion") + ".name") + " ";
+		if(Food.isInfused(is))
+			s += StatCollector.translateToLocal(Food.getInfusion(is) + ".name") + " ";
 		s += StatCollector.translateToLocal(this.getUnlocalizedNameInefficiently(is) + ".name");
 		s += getCookedLevelString(is);
 		return s.trim();


### PR DESCRIPTION
An exception is thrown if the itemstack does not have a tag compound.
Have altered the code to use method calls instead. This was found when using the NEI mod, a blank name would be returned because of the exception.
1. Added getInfusion method.
2. Used IsInfused and getInfusion methods.
