### PR TITLE
Show Kittys birthday even if month is less than 18 days long.

### DIFF
--- a/src/Common/com/bioxx/tfc/GUI/GuiCalendar.java
+++ b/src/Common/com/bioxx/tfc/GUI/GuiCalendar.java
@@ -101,8 +101,11 @@ public class GuiCalendar extends GuiScreen
 		int month = TFC_Time.currentMonth;
 		String day = TFC_Time.DAYS[TFC_Time.getDayOfWeek()];
 
-		if (month == 3 && dom == 18)
+		if (month == 3 && (dom == 18 || (TFC_Time.daysInMonth < 18 && dom == TFC_Time.daysInMonth)))
+		{
+			dom = 18;
 			day = StatCollector.translateToLocal("gui.Calendar.DateKitty");
+		}
 		else if(month == 4 && dom == 7)
 			day = StatCollector.translateToLocal("gui.Calendar.DateBioxx");
 		else if(month == 8 && dom == 2)


### PR DESCRIPTION
Kittys birthday never appears if using the default year length.
To display it if the month length is less than 18 days, the last June day is assumed/displayed as 18th - Kitty deserves it.
This should not change the game mechanics at all since it is only being displayed.