### PR TITLE
Add guard to catch NPE ore blocks early.

### DIFF
--- a/src/Common/com/bioxx/tfc/WorldGen/Generators/OreSpawnData.java
+++ b/src/Common/com/bioxx/tfc/WorldGen/Generators/OreSpawnData.java
@@ -18,6 +18,11 @@ public class OreSpawnData
 	public OreSpawnData(String T, String S, String BN, int M, int R, String[] baseRocks)
 	{
 		block = Block.getBlockFromName(BN);
+
+		if (null == block) {
+			throw new java.lang.NullPointerException(String.format("null block returned for '%s'", BN));
+		}
+		
 		meta = M;
 		rarity = R;
 		if(T.equals("default"))

--- a/src/Common/com/bioxx/tfc/WorldGen/Generators/WorldGenMinable.java
+++ b/src/Common/com/bioxx/tfc/WorldGen/Generators/WorldGenMinable.java
@@ -308,13 +308,25 @@ public class WorldGenMinable extends WorldGenerator
 
 				if(isCorrectRockType && isCorrectMeta)
 				{
-					world.setBlock(posX, posY, posZ, MPBlock, minableBlockMeta, 2);
-					TEOre te = (TEOre)world.getTileEntity(posX, posY, posZ);
-					if(te!= null)
-					{
-						te.baseBlockID = Block.getIdFromBlock(b);
-						te.baseBlockMeta = m;
-						te.extraData = (byte)grade;
+					try {
+						world.setBlock(posX, posY, posZ, MPBlock, minableBlockMeta, 2);
+						TEOre te = (TEOre)world.getTileEntity(posX, posY, posZ);
+						if(te!= null)
+						{
+							te.baseBlockID = Block.getIdFromBlock(b);
+							te.baseBlockMeta = m;
+							te.extraData = (byte)grade;
+						}
+					} catch (java.lang.NullPointerException e) {
+						System.err.println("Invalid entry in TFCOres.cfg or injected later.\n"
+								+ "Attempting to get block data:"
+								+ "\nWorld block: " + String.valueOf(b)
+								+ "\nWorld meta: " + String.valueOf(m)
+								+ "\nRequested block: " + String.valueOf(MPBlock)
+								+ "\nRequested as item: " + String.valueOf(Block.getIdFromBlock(MPBlock))
+								+ "\nRequested meta: " + String.valueOf(minableBlockMeta)
+								);
+						throw e;
 					}
 				}
 				blocksMade++;


### PR DESCRIPTION
Add guard to catch NPE ore blocks early.

    [21:56:52] [Client thread/ERROR] [FML]: Fatal errors were detected during the transition from PREINITIALIZATION to INITIALIZATION. Loading cannot continue
    ...
    [21:56:52] [Client thread/ERROR] [FML]: The following problems were captured during this phase
    [21:56:52] [Client thread/ERROR] [FML]: Caught exception from terrafirmacraft
    java.lang.NullPointerException: null block returned for 'Eln:Eln.Ore'
    at com.bioxx.tfc.WorldGen.Generators.OreSpawnData.<init>(OreSpawnData.java:23) ~[OreSpawnData.class:?]
    at com.bioxx.tfc.WorldGen.Generators.OreSpawnData.<init>(OreSpawnData.java:49) ~[OreSpawnData.class:?]
    at com.bioxx.tfc.TerraFirmaCraft.loadOre(TerraFirmaCraft.java:554) ~[TerraFirmaCraft.class:?]
    at com.bioxx.tfc.TerraFirmaCraft.preInit(TerraFirmaCraft.java:113) ~[TerraFirmaCraft.class:?]
