### PR TITLE
Solve alloy mixing bug allowing an alloy be an ingredient of itself (treat it as if is not present).

### DIFF
--- a/src/Common/com/bioxx/tfc/Core/Metal/Alloy.java
+++ b/src/Common/com/bioxx/tfc/Core/Metal/Alloy.java
@@ -77,8 +77,12 @@ public class Alloy
 			{
 				if(alloyMix.metalType == this.outputType)
 				{
-					isAlloyInMix = true;
 					alloyPercentage = alloyMix.metal;
+					//Alloy detected, if >= 100% don't trick -> Unknown alloy
+					if(alloyPercentage < 100f)
+					{
+						isAlloyInMix = true;
+					} 
 					break;
 				}
 			}

--- a/src/Common/com/bioxx/tfc/Core/Metal/Alloy.java
+++ b/src/Common/com/bioxx/tfc/Core/Metal/Alloy.java
@@ -68,13 +68,41 @@ public class Alloy
 
 	public Alloy matches(List<AlloyMetal> a)
 	{
+		//Find if the alloy searched is part of the ingredients mix. Only have sense for >1 ingredients alloys.
+		boolean isAlloyInMix = false;
+		float alloyPercentage = 0;
+		if(a.size() > 1)
+		{
+			for(AlloyMetal alloyMix: a)
+			{
+				if(alloyMix.metalType == this.outputType)
+				{
+					isAlloyInMix = true;
+					alloyPercentage = alloyMix.metal;
+					break;
+				}
+			}
+		}
+	
 		Iterator<AlloyMetal> iter = a.iterator();
 		boolean matches = true;
 		int amount = 0;
 		while(iter.hasNext() && matches == true)
 		{
 			AlloyMetal am = iter.next();
-			matches = searchForAlloyMetal(am);
+			if(isAlloyInMix)
+			{
+				//if the alloy is part of the mix don't search for it, else adjust ratio for search.
+				if(am.metalType == this.outputType)
+				{
+					matches = true;
+				} else {
+					float partialPercentage = 100f * am.metal / (100f - alloyPercentage);
+					matches = searchForAlloyMetal(new AlloyMetal(am.metalType, partialPercentage));
+				}
+			} else {
+				matches = searchForAlloyMetal(am);
+			}
 			amount += am.metal;
 		}
 


### PR DESCRIPTION
When try to match an alloy, if the alloy is present on the ingredients it will skip it from comparing with the alloy recipe, and compare the rest of ingredients with percentages shifted as is there it's no alloy present.

It's not exploitable as the alloy didn't convert on it's parts and didn't count for the alloy match. Basically try to trick the searchForAlloyMetal function as if the alloy (the same that is trying to match) is not on the ingredients.
