### PR TITLE
changed temperature/dayOfYear distribution:

### DIFF
--- a/src/Common/com/bioxx/tfc/Core/TFC_Climate.java
+++ b/src/Common/com/bioxx/tfc/Core/TFC_Climate.java
@@ -135,19 +135,23 @@ public class TFC_Climate
 
 	protected static float getTemp(World world,int x, int z)
 	{
-		return getTemp(world, TFC_Time.currentDay,TFC_Time.getHour(), x, z);
+		return getTemp0(world, TFC_Time.currentDay,TFC_Time.getHour(), x, z, false);
 	}
 
 	protected static float getTemp(World world, int day, int hour, int x, int z)
 	{
+		return getTemp0(world, day, hour, x, z, false);
+	}
+	
+	protected static float getBioTemp(World world,int day, int x, int z)
+	{
+		return getTemp0(world, day, 0, x, z, true);
+	}
+	
+	private static float getTemp0(World world, int day, int hour, int x, int z, boolean bio)
+	{
 		if(TFC_Climate.getCacheManager(world) != null)
 		{
-			/*float cacheTemp = TFC_Climate.getCacheManager(world).getTemp(x, z, th);
-			if(cacheTemp != Float.MIN_VALUE)
-			{
-				return cacheTemp;
-			}*/
-
 			float zMod = getZFactor(z);
 			float zTemp = (zMod * getMaxTemperature())-20 + ((zMod - 0.5f)*10);
 
@@ -162,57 +166,29 @@ public class TFC_Climate
 
 			int dayOfMonth = TFC_Time.getDayOfMonthFromDayOfYear(day);
 
-			int h = (hour - 6) % TFC_Time.hoursInDay;
-			if (h < 0) {
-				h += TFC_Time.hoursInDay;
-			}
-			
 			float hourMod;
-			if(h < 12)
-				hourMod = ((float)h / 11) * 0.3F;
-			else
-				hourMod = 0.3F - ((((float)h-12) / 11) * 0.3F);
+			float dailyTemp;
+			if (bio) {
+				hourMod = 0.2f;
+				dailyTemp = 0;
+			} else {
+				int h = (hour - 6) % TFC_Time.hoursInDay;
+				if (h < 0) {
+					h += TFC_Time.hoursInDay;
+				}
 
-			float dailyTemp = WeatherManager.getInstance().getDailyTemp(day);
+				if(h < 12)
+					hourMod = ((float)h / 11) * 0.3F;
+				else
+					hourMod = 0.3F - ((((float)h-12) / 11) * 0.3F);
+				
+				dailyTemp = WeatherManager.getInstance().getDailyTemp(day);
+			}
 
 			float monthDelta = ((monthTemp-lastMonthTemp) * dayOfMonth) / TFC_Time.daysInMonth;
 			float temp = lastMonthTemp + monthDelta;
 
 			temp += dailyTemp + (hourMod*(zTemp + dailyTemp));
-
-			if(temp >= 12)
-				temp += (8*rainMod)*zMod;
-			else
-				temp -= (8*rainMod)*zMod;
-				
-			//TFC_Climate.getCacheManager(world).addTemp(x, z, th, temp);
-			return temp;
-		}
-		return -10;
-	}
-
-	protected static float getBioTemp(World world,int day, int x, int z)
-	{
-		if(TFC_Climate.getCacheManager(world) != null)
-		{
-			float zMod = getZFactor(z);
-			float zTemp = (zMod * getMaxTemperature())-20 + ((zMod - 0.5f)*10);
-
-			float rain = getRainfall(world, x, Global.SEALEVEL, z);
-			float rainMod = (1-(rain/4000))*zMod;
-
-			int month = TFC_Time.getSeasonFromDayOfYear(day,z);
-			int lastMonth = TFC_Time.getSeasonFromDayOfYear(day-TFC_Time.daysInMonth,z);
-			
-			float monthTemp = getMonthTemp(month, z);
-			float lastMonthTemp = getMonthTemp(lastMonth, z);
-
-			int dayOfMonth =  TFC_Time.getDayOfMonthFromDayOfYear(day);
-
-			float hourMod = 0.2f;
-
-			float monthDelta = ((monthTemp-lastMonthTemp) * dayOfMonth) / TFC_Time.daysInMonth;
-			float temp = lastMonthTemp + monthDelta;
 
 			if(temp >= 12)
 				temp += (8*rainMod)*zMod;
@@ -234,7 +210,7 @@ public class TFC_Climate
 
 	protected static float getTempSpecificDay(World world,int day, int x, int z)
 	{
-		return getTemp(world, day,12, x, z);
+		return getTemp(world, day, 12, x, z);
 	}
 
 	public static float getHeightAdjustedTemp(World world, int x, int y, int z)

--- a/src/Common/com/bioxx/tfc/Core/TFC_Climate.java
+++ b/src/Common/com/bioxx/tfc/Core/TFC_Climate.java
@@ -20,7 +20,6 @@ public class TFC_Climate
 	private static final float[] yFactorCache = new float[441];
 	private static final float[] zFactorCache = new float[30001];
 	private static final float[][] monthTempCache = new float[12][30001];
-	private static final float[][] monthTempFactorCache = new float[12][30001];
 
 	//private static int[][] insolationMap;
 
@@ -79,6 +78,11 @@ public class TFC_Climate
 
 				switch(month)
 				{
+				case 10:
+				{
+					monthTempCache[month][zCoord] = (float)(MAXTEMP-13.5*latitudeFactor - (latitudeFactor*55));
+					break;
+				}
 				case 9:
 				case 11:
 				{
@@ -114,77 +118,6 @@ public class TFC_Climate
 					monthTempCache[month][zCoord] = (float)(MAXTEMP -1.5*latitudeFactor- (latitudeFactor*27));
 					break;
 				}
-				case 10:
-				{
-					monthTempCache[month][zCoord] = (float)(MAXTEMP-15*latitudeFactor - (latitudeFactor*60));
-					break;
-				}
-				}
-
-				float diff = (1-factor) / 6;
-
-				switch(month)
-				{
-				case 11:
-				{
-					monthTempFactorCache[month][zCoord] = 1-(diff*4);
-					break;
-				}
-				case 0:
-				{
-					monthTempFactorCache[month][zCoord] = 1-(diff*3);
-					break;
-				}
-				case 1:
-				{
-					monthTempFactorCache[month][zCoord] = 1-(diff*2);
-					break;
-				}
-				case 2:
-				{
-					monthTempFactorCache[month][zCoord] = 1-(diff*1);
-					break;
-				}
-				case 3:
-				{
-					monthTempFactorCache[month][zCoord] = 1-(diff);
-					break;
-				}
-				case 4:
-				{
-					monthTempFactorCache[month][zCoord] = 1F;
-					break;
-				}
-				case 5:
-				{
-					monthTempFactorCache[month][zCoord] = 1-(diff*1.2f);
-					break;
-				}
-				case 6:
-				{
-					monthTempFactorCache[month][zCoord] = 1-(diff*2.4f);
-					break;
-				}
-				case 7:
-				{
-					monthTempFactorCache[month][zCoord] = 1-(diff*3.6f);
-					break;
-				}
-				case 8:
-				{
-					monthTempFactorCache[month][zCoord] = 1-(diff*4.8f);
-					break;
-				}
-				case 9:
-				{
-					monthTempFactorCache[month][zCoord] = factor;
-					break;
-				}
-				case 10:
-				{
-					monthTempFactorCache[month][zCoord] = 1-(diff*5);
-					break;
-				}
 				}
 			}
 		}
@@ -218,61 +151,40 @@ public class TFC_Climate
 			float zMod = getZFactor(z);
 			float zTemp = (zMod * getMaxTemperature())-20 + ((zMod - 0.5f)*10);
 
-			float rainMod = (1-((getRainfall(world, x, Global.SEALEVEL, z))/4000))*zMod;
+			float rain = getRainfall(world, x, Global.SEALEVEL, z);
+			float rainMod = (1-(rain/4000))*zMod;
 
-			int _month = TFC_Time.getSeasonFromDayOfYear(day,z);
-			int _lastmonth = TFC_Time.getSeasonFromDayOfYear(day-TFC_Time.daysInMonth,z);
+			int month = TFC_Time.getSeasonFromDayOfYear(day,z);
+			int lastMonth = TFC_Time.getSeasonFromDayOfYear(day-TFC_Time.daysInMonth,z);
+			
+			float monthTemp = getMonthTemp(month, z);
+			float lastMonthTemp = getMonthTemp(lastMonth, z);
 
-			float mod = getMonthTempFactor(_month, z);
-			float modLast = getMonthTempFactor(_lastmonth, z);
-			int day2 = day - ((day/TFC_Time.daysInMonth)*TFC_Time.daysInMonth);
+			int dayOfMonth = TFC_Time.getDayOfMonthFromDayOfYear(day);
 
 			int h = (hour - 6) % TFC_Time.hoursInDay;
 			if (h < 0) {
 				h += TFC_Time.hoursInDay;
 			}
 			
-			float hourMod = 0;
+			float hourMod;
 			if(h < 12)
 				hourMod = ((float)h / 11) * 0.3F;
 			else
 				hourMod = 0.3F - ((((float)h-12) / 11) * 0.3F);
 
-			float monthMod = 0;
-			float temp = 0;
-
 			float dailyTemp = WeatherManager.getInstance().getDailyTemp(day);
 
-			if(modLast > mod)
-			{
-				monthMod = ((modLast-mod)/TFC_Time.daysInMonth)*day2;
-				monthMod = (modLast - monthMod);
+			float monthDelta = ((monthTemp-lastMonthTemp) * dayOfMonth) / TFC_Time.daysInMonth;
+			float temp = lastMonthTemp + monthDelta;
 
-				temp += getMonthTemp(_month,z) + dailyTemp;//((zTemp + dailyTemp));
-				if(temp < 0)monthMod = 1 - monthMod;
-				temp *= monthMod;
-				temp += (hourMod*(zTemp + dailyTemp));
+			temp += dailyTemp + (hourMod*(zTemp + dailyTemp));
 
-				if(temp >= 12)
-					temp += (8*rainMod)*zMod;
-				else
-					temp -= (8*rainMod)*zMod;
-			}
+			if(temp >= 12)
+				temp += (8*rainMod)*zMod;
 			else
-			{
-				monthMod = ((modLast-mod)/TFC_Time.daysInMonth)*day2;
-				monthMod = (modLast + monthMod);
-
-				temp += getMonthTemp(_month,z) + dailyTemp;//((zTemp + dailyTemp));
-				if(temp < 0)monthMod = 1 - monthMod;
-				temp *= monthMod;
-				temp += (hourMod*(zTemp + dailyTemp));
-
-				if(temp >= 12)
-					temp += (8*rainMod)*zMod;
-				else
-					temp -= (8*rainMod)*zMod;
-			}
+				temp -= (8*rainMod)*zMod;
+				
 			//TFC_Climate.getCacheManager(world).addTemp(x, z, th, temp);
 			return temp;
 		}
@@ -289,47 +201,24 @@ public class TFC_Climate
 			float rain = getRainfall(world, x, Global.SEALEVEL, z);
 			float rainMod = (1-(rain/4000))*zMod;
 
-			int _season = TFC_Time.getSeasonFromDayOfYear(day,z);
-			int _lastseason = TFC_Time.getSeasonFromDayOfYear(day-TFC_Time.daysInMonth,z);
-
-			float monthModifier = getMonthTempFactor(_season, z);
-			float lastMonthModifier = getMonthTempFactor(_lastseason, z);
+			int month = TFC_Time.getSeasonFromDayOfYear(day,z);
+			int lastMonth = TFC_Time.getSeasonFromDayOfYear(day-TFC_Time.daysInMonth,z);
+			
+			float monthTemp = getMonthTemp(month, z);
+			float lastMonthTemp = getMonthTemp(lastMonth, z);
 
 			int dayOfMonth =  TFC_Time.getDayOfMonthFromDayOfYear(day);
 
 			float hourMod = 0.2f;
 
-			float monthMod = 0;
-			float temp = 0;
+			float monthDelta = ((monthTemp-lastMonthTemp) * dayOfMonth) / TFC_Time.daysInMonth;
+			float temp = lastMonthTemp + monthDelta;
 
-			if(lastMonthModifier > monthModifier)
-			{
-				monthMod = ((lastMonthModifier - monthModifier) / TFC_Time.daysInMonth) * dayOfMonth;
-				monthMod = (lastMonthModifier - monthMod);
-
-				temp += getMonthTemp(_season,z);//((zTemp));
-				if(temp < 0)monthMod = 1 - monthMod;
-				temp *= monthMod;
-				temp += (hourMod * (zTemp));
-				if(temp >= 12)
-					temp += (8 * rainMod) * zMod;
-				else
-					temp -= (8 * rainMod) * zMod;
-			}
+			if(temp >= 12)
+				temp += (8*rainMod)*zMod;
 			else
-			{
-				monthMod = ((lastMonthModifier - monthModifier) / TFC_Time.daysInMonth) * dayOfMonth;
-				monthMod = (lastMonthModifier + monthMod);
-
-				temp += getMonthTemp(_season,z);//((zTemp));
-				if(temp < 0)monthMod = 1 - monthMod;
-				temp *= monthMod;
-				temp += (hourMod * (zTemp));
-				if(temp >= 12)
-					temp += (8 * rainMod) * zMod;
-				else
-					temp -= (8 * rainMod) * zMod;
-			}
+				temp -= (8*rainMod)*zMod;
+				
 			return temp;
 		}
 		return -10;
@@ -341,14 +230,6 @@ public class TFC_Climate
 			z = -z;
 		if(z > getMaxZPos()) z = (getMaxZPos());
 		return monthTempCache[season][z];
-	}
-
-	protected static float getMonthTempFactor(int season, int z)
-	{
-		if(z < 0)
-			z = -z;
-		if(z > getMaxZPos()) z = (getMaxZPos());
-		return monthTempFactorCache[season][z];
 	}
 
 	protected static float getTempSpecificDay(World world,int day, int x, int z)


### PR DESCRIPTION
- removed monthly 'steps'
- flattened peak at month 10
- deleted monthTempFactorCache

In my world I had snow at the last day of January and only at the last day of February, but no snow at the other days in February. I plotted the result form getTemp(), without the random part (dailyTemp), for Z=10000 (southern Hemisphere) and each day:
![original](https://cloud.githubusercontent.com/assets/2377128/5693213/58a923a0-990b-11e4-9c9d-bd593b503a71.jpg)
(each color line represents the temperature for different hours [0,6,12,18])

I do not believe that the monthly steps are desired, neither the downward inclination of each step after day 48 (second year half).
I changed the formula to eliminate the steps but trying to maintain the same edge values. I just changed the value for month 10 (day 40 in the plot since Z>0 - southern Hemisphere) to eliminate the peak: 
![peak](https://cloud.githubusercontent.com/assets/2377128/5693241/9d6bb808-990c-11e4-859e-e99e4466fdaf.jpg)

Here the resulting plot for Z=10000
![modified](https://cloud.githubusercontent.com/assets/2377128/5693249/b77034ae-990c-11e4-9311-023832ca652e.jpg)

Also tested for other values of Z - same results (except for Z=0) and there is still the random daily variation: -5 to +5 (not included in the plots)
 
Probably not so important/remarkable but since I already had spent some time checking the code I thought I could change it... and at least saving the memory for monthTempFactorCache