### PR TITLE
Excludes meals from shift-clicking into the crafting grid

### DIFF
--- a/src/Common/com/bioxx/tfc/Containers/ContainerPlayerTFC.java
+++ b/src/Common/com/bioxx/tfc/Containers/ContainerPlayerTFC.java
@@ -134,7 +134,7 @@ public class ContainerPlayerTFC extends ContainerPlayer
 						return null;
 				}
 			}
-			else if (par2 >= 9 && par2 < 45 && origStack.getItem() instanceof IFood && !(origStack.getItem() instanceof ItemMeal)&& !isCraftingGridFull())
+			else if (par2 >= 9 && par2 < 45 && origStack.getItem() instanceof IFood && !(origStack.getItem() instanceof ItemMeal) && !isCraftingGridFull())
 			{
 				if (!this.mergeItemStack(slotStack, 1, 5, false) && slotStack.stackSize == 0)
 					return null;

--- a/src/Common/com/bioxx/tfc/Containers/ContainerPlayerTFC.java
+++ b/src/Common/com/bioxx/tfc/Containers/ContainerPlayerTFC.java
@@ -15,6 +15,7 @@ import com.bioxx.tfc.Handlers.CraftingHandler;
 import com.bioxx.tfc.Handlers.FoodCraftingHandler;
 import com.bioxx.tfc.Items.ItemTFCArmor;
 import com.bioxx.tfc.api.Interfaces.IFood;
+import com.bioxx.tfc.Food.ItemMeal;
 
 public class ContainerPlayerTFC extends ContainerPlayer
 {
@@ -133,7 +134,7 @@ public class ContainerPlayerTFC extends ContainerPlayer
 						return null;
 				}
 			}
-			else if (par2 >= 9 && par2 < 45 && origStack.getItem() instanceof IFood && !isCraftingGridFull())
+			else if (par2 >= 9 && par2 < 45 && origStack.getItem() instanceof IFood && !(origStack.getItem() instanceof ItemMeal)&& !isCraftingGridFull())
 			{
 				if (!this.mergeItemStack(slotStack, 1, 5, false) && slotStack.stackSize == 0)
 					return null;


### PR DESCRIPTION
Meals can't be combined, so prevent them from shift-clicking into the crafting grid. This allows them to be shift-clicked between the hotbar and main inventory.

Tested in SSP and SMP, including ensuring that non-meal food items still work as expected.