### PR TITLE
Respect game rule "doTileDrops" for Barrels and Chests

### DIFF
--- a/src/API/com/bioxx/tfc/api/Crafting/BarrelManager.java
+++ b/src/API/com/bioxx/tfc/api/Crafting/BarrelManager.java
@@ -3,6 +3,8 @@ package com.bioxx.tfc.api.Crafting;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.bioxx.tfc.TileEntities.TEBarrel;
+
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
@@ -15,15 +17,21 @@ public class BarrelManager
 	}
 
 	private List<BarrelRecipe> recipes;
+	private List<BarrelPreservativeRecipe> preservativeRecipes;
 
 	private BarrelManager()
 	{
 		recipes = new ArrayList<BarrelRecipe>();
+		preservativeRecipes = new ArrayList<BarrelPreservativeRecipe>();
 	}
 
 	public void addRecipe(BarrelRecipe recipe)
 	{
 		recipes.add(recipe);
+	}
+	
+	public void addPreservative(BarrelPreservativeRecipe recipe) {
+		preservativeRecipes.add(recipe);
 	}
 
 	public BarrelRecipe findMatchingRecipe(ItemStack item, FluidStack fluid, boolean sealed, int techLevel)
@@ -37,9 +45,25 @@ public class BarrelManager
 		}
 		return null;
 	}
+	
+	public BarrelPreservativeRecipe findMatchinePreservativeRepice(TEBarrel teBarrel, ItemStack item, FluidStack fluid, boolean sealed)
+	{
+		for(BarrelPreservativeRecipe recipe : preservativeRecipes){
+			if(recipe.checkForPreservation(teBarrel, fluid, item, sealed))
+				return recipe;
+		}
+		return null;
+	}
 
 	public List<BarrelRecipe> getRecipes()
 	{
 		return recipes;
 	}
+	
+	public List<BarrelPreservativeRecipe> getPreservatives()
+	{
+		return preservativeRecipes;
+	}
+
+
 }

--- a/src/API/com/bioxx/tfc/api/Crafting/BarrelPreservativeRecipe.java
+++ b/src/API/com/bioxx/tfc/api/Crafting/BarrelPreservativeRecipe.java
@@ -1,0 +1,205 @@
+package com.bioxx.tfc.api.Crafting;
+
+import com.bioxx.tfc.TileEntities.TEBarrel;
+import com.bioxx.tfc.api.Food;
+import com.bioxx.tfc.api.Enums.EnumFoodGroup;
+import com.bioxx.tfc.api.Interfaces.IFood;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+
+public class BarrelPreservativeRecipe {
+	private boolean requiresBrined = false;
+	private boolean requiresPickled = false;
+	private boolean requiresSalted = false;
+	private boolean requiresDried = false;
+	private boolean requiresSmoked = false;
+	private boolean requiresInfused = false;
+	
+	private boolean requiresSealed = false;
+	
+	private boolean allowGrains = false;
+	private boolean allowProtiens = false;
+	private boolean allowVegetables = false;
+	private boolean allowFruit = false;
+	private boolean allowDairy = false;
+	
+	private FluidStack liquidPerOz = null;
+	
+	private float environmentalDecayFactor = Float.NaN;
+	private float baseDecayModifier = Float.NaN;
+	private String preservingString;
+	
+	/***
+	 * Can be overriden by a subclass to allow preservation with checks... possibly on relative blocks.
+	 * @param barrel
+	 * @param fluid
+	 * @param itemStack
+	 * @param sealed
+	 * @return
+	 */
+	public boolean checkForPreservation(TEBarrel barrel, FluidStack fluid, ItemStack itemStack, boolean sealed){
+		if(itemStack == null || fluid == null)
+		{ 
+			return false; 
+		}
+		if(!(itemStack.getItem() instanceof IFood))
+		{
+			return false;
+		}
+		if(fluid.getFluid() != liquidPerOz.getFluid())
+		{
+			return false;
+		}
+		IFood iFood = ((IFood)itemStack.getItem());
+		float w = iFood.getFoodWeight(itemStack);
+		if(!allowGrains && iFood.getFoodGroup() == EnumFoodGroup.Grain)
+		{
+			return false;
+		}
+		if(!allowProtiens && iFood.getFoodGroup() == EnumFoodGroup.Protein)
+		{
+			return false;
+		}
+		if(!allowVegetables && iFood.getFoodGroup() == EnumFoodGroup.Vegetable)
+		{
+			return false;
+		}
+		if(!allowFruit && iFood.getFoodGroup() == EnumFoodGroup.Fruit)
+		{
+			return false;
+		}
+		if(!allowDairy && iFood.getFoodGroup() == EnumFoodGroup.Dairy)
+		{
+			return false;
+		}
+		if(requiresBrined && !Food.isBrined(itemStack))
+		{
+			return false;
+		}
+		if(requiresPickled && !Food.isPickled(itemStack))
+		{
+			return false;
+		}
+		if(requiresSalted && !Food.isSalted(itemStack))
+		{
+			return false;
+		}
+		if(requiresDried && !Food.isDried(itemStack))
+		{
+			return false;
+		}
+		if(requiresSmoked && !Food.isSmoked(itemStack))
+		{
+			return false;
+		}
+		if(requiresInfused && !Food.isInfused(itemStack))
+		{
+			return false;
+		}
+		if(requiresSealed && !sealed)
+		{
+			return false;
+		}
+		if(liquidPerOz.amount * w > fluid.amount){
+			return false;
+		}
+		return true;
+	}
+	
+	public BarrelPreservativeRecipe(FluidStack liquidPerOz, String unlocalizedPreservingLabel){
+		this.liquidPerOz = liquidPerOz;
+		this.preservingString = unlocalizedPreservingLabel;
+	}
+	
+	public BarrelPreservativeRecipe setRequiresBrined(boolean b)
+	{
+		requiresBrined = b;
+		return this;
+	}
+	
+	public BarrelPreservativeRecipe setRequiresPickled(boolean b)
+	{
+		requiresPickled = b;
+		return this;
+	}
+	
+	public BarrelPreservativeRecipe setRequiresSalted(boolean b)
+	{
+		requiresSalted = b;
+		return this;
+	}
+	
+	public BarrelPreservativeRecipe setRequiresDried(boolean b)
+	{
+		requiresDried = b;
+		return this;
+	}
+	
+	public BarrelPreservativeRecipe setRequiresSmoked(boolean b)
+	{
+		requiresSmoked = b;
+		return this;
+	}
+	
+	public BarrelPreservativeRecipe setRequiresInfused(boolean b)
+	{
+		requiresInfused = b;
+		return this;
+	}
+	
+	public BarrelPreservativeRecipe setRequiresSealed(boolean b)
+	{
+		requiresSealed = b;
+		return this;
+	}
+	
+	public BarrelPreservativeRecipe setAllowProtien(boolean b){
+		allowProtiens = b;
+		return this;
+	}
+	
+	public BarrelPreservativeRecipe setAllowGrains(boolean b){
+		allowGrains = b;
+		return this;
+	}
+	
+	public BarrelPreservativeRecipe setAllowFruit(boolean b){
+		allowGrains = b;
+		return this;
+	}
+	
+	public BarrelPreservativeRecipe setAllowVegetable(boolean b){
+		allowGrains = b;
+		return this;
+	}
+	
+	public BarrelPreservativeRecipe setAllowDairy(boolean b){
+		allowGrains = b;
+		return this;
+	}
+
+	public BarrelPreservativeRecipe setEnvironmentalDecayFactor(float rate) {
+		environmentalDecayFactor = rate;
+		return this;
+	}
+
+	public BarrelPreservativeRecipe setBaseDecayModifier(float rate) {
+		baseDecayModifier = rate;
+		return this;
+	}
+	
+	
+	public float getEnvironmentalDecayFactor(){
+		return environmentalDecayFactor;
+	}
+	
+	public float getBaseDecayModifier(){
+		return baseDecayModifier;
+	}
+
+	public String getPreservingString() {
+		return preservingString;
+	}
+
+}

--- a/src/Common/com/bioxx/tfc/Blocks/Devices/BlockBarrel.java
+++ b/src/Common/com/bioxx/tfc/Blocks/Devices/BlockBarrel.java
@@ -129,7 +129,7 @@ public class BlockBarrel extends BlockTerraContainer
 		if (!world.isRemote)
 		{
 			TEBarrel te = (TEBarrel)world.getTileEntity(x, y, z);
-			if (te != null && te.shouldDropItem)
+			if (te != null && te.shouldDropItem && world.getGameRules().getGameRuleBooleanValue("doTileDrops"))
 			{
 				if(te.getSealed())
 				{

--- a/src/Common/com/bioxx/tfc/Blocks/Devices/BlockChestTFC.java
+++ b/src/Common/com/bioxx/tfc/Blocks/Devices/BlockChestTFC.java
@@ -92,7 +92,7 @@ public class BlockChestTFC extends BlockTerraContainer
 	@Override
 	public void onBlockPreDestroy(World world, int i, int j, int k, int meta) 
 	{
-		if(!world.isRemote)
+		if(!world.isRemote && world.getGameRules().getGameRuleBooleanValue("doTileDrops"))
 		{
 			int damageValue = getDamageValue(world, i, j, k);
 			EntityItem ei = new EntityItem(world, i, j, k, new ItemStack(TFCBlocks.Chest, 1, damageValue));

--- a/src/Common/com/bioxx/tfc/GUI/GuiBarrel.java
+++ b/src/Common/com/bioxx/tfc/GUI/GuiBarrel.java
@@ -30,6 +30,8 @@ import com.bioxx.tfc.api.TFCFluids;
 import com.bioxx.tfc.api.TFCItems;
 import com.bioxx.tfc.api.Constant.Global;
 import com.bioxx.tfc.api.Crafting.BarrelBriningRecipe;
+import com.bioxx.tfc.api.Crafting.BarrelManager;
+import com.bioxx.tfc.api.Crafting.BarrelPreservativeRecipe;
 import com.bioxx.tfc.api.Enums.EnumFoodGroup;
 import com.bioxx.tfc.api.Interfaces.IFood;
 
@@ -339,20 +341,20 @@ public class GuiBarrel extends GuiContainerTFC
 				}
 			}
 			else if (barrelTE.recipe == null && barrelTE.getSealed() && barrelTE.getFluidStack() != null && inStack != null && inStack.getItem() instanceof IFood &&
-					barrelTE.getFluidStack().getFluid() == TFCFluids.VINEGAR)
+					barrelTE.getFluidStack().getFluid() == TFCFluids.VINEGAR && !Food.isPickled(inStack) && Food.getWeight(inStack) / barrelTE.getFluidStack().amount <= Global.FOOD_MAX_WEIGHT / barrelTE.getMaxLiquid())
 			{
-				if (!Food.isPickled(inStack) && Food.getWeight(inStack) / barrelTE.getFluidStack().amount <= Global.FOOD_MAX_WEIGHT / barrelTE.getMaxLiquid())
+				if ((((IFood) inStack.getItem()).getFoodGroup() == EnumFoodGroup.Fruit || ((IFood) inStack.getItem()).getFoodGroup() == EnumFoodGroup.Vegetable ||
+						((IFood) inStack.getItem()).getFoodGroup() == EnumFoodGroup.Protein || ((IFood) inStack.getItem()) == TFCItems.Cheese) &&
+						Food.isBrined(inStack))
 				{
-					if ((((IFood) inStack.getItem()).getFoodGroup() == EnumFoodGroup.Fruit || ((IFood) inStack.getItem()).getFoodGroup() == EnumFoodGroup.Vegetable ||
-							((IFood) inStack.getItem()).getFoodGroup() == EnumFoodGroup.Protein || ((IFood) inStack.getItem()) == TFCItems.Cheese) &&
-							Food.isBrined(inStack))
-					{
-						drawCenteredString(this.fontRendererObj, StatCollector.translateToLocal("gui.barrel.pickling"), guiLeft + 88, guiTop + 72, 0x555555);
-					}
+					drawCenteredString(this.fontRendererObj, StatCollector.translateToLocal("gui.barrel.pickling"), guiLeft + 88, guiTop + 72, 0x555555);
 				}
-				else if (Food.isPickled(inStack) && Food.getWeight(inStack) / barrelTE.getFluidStack().amount <= Global.FOOD_MAX_WEIGHT / barrelTE.getMaxLiquid() * 2)
-				{
-					drawCenteredString(this.fontRendererObj, StatCollector.translateToLocal("gui.barrel.preserving"), guiLeft + 88, guiTop + 72, 0x555555);
+			}
+			else
+			{
+				BarrelPreservativeRecipe preservative = BarrelManager.getInstance().findMatchinePreservativeRepice(barrelTE, inStack, barrelTE.getFluidStack(), barrelTE.getSealed());
+				if(preservative!=null){
+					drawCenteredString(this.fontRendererObj, StatCollector.translateToLocal(preservative.getPreservingString()), guiLeft+88, guiTop+72, 0x555555);
 				}
 			}
 

--- a/src/Common/com/bioxx/tfc/TileEntities/TEBarrel.java
+++ b/src/Common/com/bioxx/tfc/TileEntities/TEBarrel.java
@@ -2,6 +2,8 @@ package com.bioxx.tfc.TileEntities;
 
 import java.util.Random;
 
+import scala.collection.script.End;
+
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Items;
@@ -29,6 +31,7 @@ import com.bioxx.tfc.api.Crafting.BarrelBriningRecipe;
 import com.bioxx.tfc.api.Crafting.BarrelLiquidToLiquidRecipe;
 import com.bioxx.tfc.api.Crafting.BarrelManager;
 import com.bioxx.tfc.api.Crafting.BarrelMultiItemRecipe;
+import com.bioxx.tfc.api.Crafting.BarrelPreservativeRecipe;
 import com.bioxx.tfc.api.Crafting.BarrelRecipe;
 import com.bioxx.tfc.api.Crafting.BarrelVinegarRecipe;
 import com.bioxx.tfc.api.Enums.EnumFoodGroup;
@@ -575,11 +578,8 @@ public class TEBarrel extends NetworkTileEntity implements IInventory
 	{
 		if(!worldObj.isRemote)
 		{
-			DecayTickType decayTickType = DecayTickType.Standard;
 			ItemStack itemstack = storage[0]; 
-			float liquidToFoodRatioBrine = Global.FOOD_MAX_WEIGHT/10000f;//0.016
-			float liquidToFoodRatioVinegar = Global.FOOD_MAX_WEIGHT/5000f;//0.032
-
+			BarrelPreservativeRecipe preservative = BarrelManager.getInstance().findMatchinePreservativeRepice(this, itemstack, fluid, sealed);
 			if (itemstack != null && fluid != null && fluid.getFluid() == TFCFluids.FRESHWATER)
 			{
 				if(TFC_ItemHeat.HasTemp(itemstack))
@@ -597,16 +597,7 @@ public class TEBarrel extends NetworkTileEntity implements IInventory
 			if(fluid != null && itemstack != null && itemstack.getItem() instanceof IFood)
 			{
 				float w = ((IFood)itemstack.getItem()).getFoodWeight(itemstack);
-				if(fluid.getFluid() == TFCFluids.BRINE)
-				{
-					if(Food.isBrined(itemstack))
-					{
-						//Do a calculation to see if there is enough Brine here to cover the food. If there is then we perform our non-standard decay tick.
-						if(w/fluid.amount <= liquidToFoodRatioBrine)
-							decayTickType = DecayTickType.Brine;
-					}
-				}
-				else if(fluid.getFluid() == TFCFluids.VINEGAR)
+				if(fluid.getFluid() == TFCFluids.VINEGAR)
 				{
 					//If the food is brined then we attempt to pickle it
 					if(Food.isBrined(itemstack) && !Food.isPickled(itemstack) && w/fluid.amount <= Global.FOOD_MAX_WEIGHT/this.getMaxLiquid() && this.getSealed() &&
@@ -615,27 +606,30 @@ public class TEBarrel extends NetworkTileEntity implements IInventory
 						fluid.amount -= 1 * w;
 						Food.setPickled(itemstack, true);
 					}
-					//Do a calculation to see if there is enough Vinegar here to cover the food. If there is and the item has been properly pickled 
-					//then we perform our non-standard decay tick. If the food is in the process of pickling then we decay as if we were in brine.
-					if(Food.isPickled(itemstack) && w/fluid.amount <= liquidToFoodRatioVinegar)
-						decayTickType = DecayTickType.Vinegar;
-					else if(Food.isBrined(itemstack) && w/fluid.amount <= liquidToFoodRatioBrine)
-						decayTickType = DecayTickType.Brine;
 				}
 			}
 
-
-			if(decayTickType == DecayTickType.Standard)
+			if(preservative == null)
 			{
+				// No preservative was matched - decay normally
 				TFC_Core.handleItemTicking(this, this.worldObj, xCoord, yCoord, zCoord);
 			}
-			else if(decayTickType == DecayTickType.Brine)
+			else
 			{
-				TFC_Core.handleItemTicking(this, this.worldObj, xCoord, yCoord, zCoord, 0.75f);
-			}
-			else if(decayTickType == DecayTickType.Vinegar)
-			{
-				TFC_Core.handleItemTicking(this, this.worldObj, xCoord, yCoord, zCoord, 0.25f, 0.1f);
+				float env = preservative.getEnvironmentalDecayFactor();
+				float base = preservative.getBaseDecayModifier();
+				if(env == Float.NaN || env < 0.0)
+				{
+					TFC_Core.handleItemTicking(this, this.worldObj, xCoord, yCoord, zCoord);
+				}
+				else if(base == Float.NaN || base < 0.0)
+				{
+					TFC_Core.handleItemTicking(this, this.worldObj, xCoord, yCoord, zCoord, env);
+				}
+				else
+				{
+					TFC_Core.handleItemTicking(this, this.worldObj, xCoord, yCoord, zCoord, env, base);
+				}
 			}
 
 			//If lightning can strike here then it means that the barrel can see the sky, so rain can hit it. If true then we fill
@@ -916,12 +910,15 @@ public class TEBarrel extends NetworkTileEntity implements IInventory
 		BarrelManager.getInstance().addRecipe(new BarrelMultiItemRecipe(new ItemStack(TFCItems.Jute, 1, 0), new FluidStack(TFCFluids.FRESHWATER, 200), new ItemStack(TFCItems.JuteFibre, 1, 0), new FluidStack(TFCFluids.FRESHWATER, 200)).setMinTechLevel(0));
 		BarrelManager.getInstance().addRecipe(new BarrelLiquidToLiquidRecipe(new FluidStack(TFCFluids.MILK, 9000), new FluidStack(TFCFluids.VINEGAR, 1000), new FluidStack(TFCFluids.MILKVINEGAR, 10000)).setSealedRecipe(false).setMinTechLevel(0).setRemovesLiquid(false));
 		BarrelManager.getInstance().addRecipe(new BarrelLiquidToLiquidRecipe(new FluidStack(TFCFluids.MILKVINEGAR, 9000), new FluidStack(TFCFluids.MILK, 1000), new FluidStack(TFCFluids.MILKVINEGAR, 10000)).setSealedRecipe(false).setMinTechLevel(0).setRemovesLiquid(false));
-	}
+		// 5000mb / 160oz = 31.25
+		// 10000mb / 160oz = 62.5
+		// FluidStack naturally only takes int so I rounded down
+		BarrelPreservativeRecipe picklePreservative = new BarrelPreservativeRecipe(new FluidStack(TFCFluids.VINEGAR,31),"gui.barrel.preserving").setAllowDairy(true).setAllowFruit(true).setAllowProtien(true).setAllowVegetable(true).setRequiresPickled(true).setEnvironmentalDecayFactor(0.25f).setBaseDecayModifier(0.1f).setRequiresSealed(true);
+		BarrelPreservativeRecipe brineInBrinePreservative = new BarrelPreservativeRecipe(new FluidStack(TFCFluids.BRINE,62),"gui.barrel.preserving").setAllowDairy(true).setAllowFruit(true).setAllowProtien(true).setAllowVegetable(true).setRequiresBrined(true).setEnvironmentalDecayFactor(0.75f).setRequiresSealed(true);
+		BarrelPreservativeRecipe brineInVinegarPreservative = new BarrelPreservativeRecipe(new FluidStack(TFCFluids.VINEGAR,62),"gui.barrel.preserving").setAllowDairy(true).setAllowFruit(true).setAllowProtien(true).setAllowVegetable(true).setRequiresBrined(true).setEnvironmentalDecayFactor(0.75f).setRequiresSealed(true);
+		BarrelManager.getInstance().addPreservative(picklePreservative);
+		BarrelManager.getInstance().addPreservative(brineInBrinePreservative);
+		BarrelManager.getInstance().addPreservative(brineInVinegarPreservative);
 
-	private enum DecayTickType
-	{
-		Standard,
-		Brine,
-		Vinegar;
 	}
 }


### PR DESCRIPTION
A running bug with Archimedes mod was that barrels, large vessels, and chests would spawn a copy when destroyed during vehicle assembly. This minor alteration checks game rule before spawning an item in.