### PR TITLE
- Fixed Chest and Barrel dropping when doTileDrops is false.

### DIFF
--- a/src/Common/com/bioxx/tfc/Blocks/Devices/BlockBarrel.java
+++ b/src/Common/com/bioxx/tfc/Blocks/Devices/BlockBarrel.java
@@ -129,7 +129,7 @@ public class BlockBarrel extends BlockTerraContainer
 		if (!world.isRemote)
 		{
 			TEBarrel te = (TEBarrel)world.getTileEntity(x, y, z);
-			if (te != null && te.shouldDropItem)
+			if (te != null && te.shouldDropItem && world.getGameRules().getGameRuleBooleanValue("doTileDrops"))
 			{
 				if(te.getSealed())
 				{

--- a/src/Common/com/bioxx/tfc/Blocks/Devices/BlockChestTFC.java
+++ b/src/Common/com/bioxx/tfc/Blocks/Devices/BlockChestTFC.java
@@ -92,7 +92,7 @@ public class BlockChestTFC extends BlockTerraContainer
 	@Override
 	public void onBlockPreDestroy(World world, int i, int j, int k, int meta) 
 	{
-		if(!world.isRemote)
+		if(!world.isRemote && world.getGameRules().getGameRuleBooleanValue("doTileDrops"))
 		{
 			int damageValue = getDamageValue(world, i, j, k);
 			EntityItem ei = new EntityItem(world, i, j, k, new ItemStack(TFCBlocks.Chest, 1, damageValue));


### PR DESCRIPTION
Fixed items dropping incorrectly when removed or destroyed when game rule "doTileDrops" is false.

This will fix one of the issues with Archimedes where container items duplicated each time the vehicle is assembled