### PR TITLE
Update TFC_OreDictionary.java

### DIFF
--- a/src/Common/com/bioxx/tfc/Core/TFC_OreDictionary.java
+++ b/src/Common/com/bioxx/tfc/Core/TFC_OreDictionary.java
@@ -137,10 +137,7 @@ public class TFC_OreDictionary
 		OreDictionary.registerOre("dustGraphite", new ItemStack(TFCItems.Powder, 1, 2)); //Graphite
 		OreDictionary.registerOre("dustSulfur", new ItemStack(TFCItems.Powder, 1, 3)); //Sulfur
 		OreDictionary.registerOre("dustSaltpeter", new ItemStack(TFCItems.Powder, 1, 4)); //Saltpeter
-		OreDictionary.registerOre("dustIron", new ItemStack(TFCItems.Powder, 1, 5)); //Hematite
 		OreDictionary.registerOre("dustLapis", new ItemStack(TFCItems.Powder, 1, 6)); //Lapis
-		OreDictionary.registerOre("dustIron", new ItemStack(TFCItems.Powder, 1, 7)); //Limonite
-		OreDictionary.registerOre("dustCopper", new ItemStack(TFCItems.Powder, 1, 8)); //Malachite
 		OreDictionary.registerOre("dustSalt", new ItemStack(TFCItems.Powder, 1, 9)); //Salt
 
 		//Ingots


### PR DESCRIPTION
Removed Hematite, Limonite and Malachite powders from dustIron and dustCopper Ore Dictionary entry respectively. Removed as it creates exploit when TFC is combined with mods with ability to smelt items.