### PR TITLE
Added Missing Flint&Steel Size Information

### DIFF
--- a/src/Common/com/bioxx/tfc/Items/Tools/ItemFlintSteel.java
+++ b/src/Common/com/bioxx/tfc/Items/Tools/ItemFlintSteel.java
@@ -15,6 +15,7 @@ import net.minecraft.world.World;
 
 import com.bioxx.tfc.Core.TFCTabs;
 import com.bioxx.tfc.Core.TFC_Core;
+import com.bioxx.tfc.Items.ItemTerra;
 import com.bioxx.tfc.TileEntities.TEPottery;
 import com.bioxx.tfc.api.TFCBlocks;
 import com.bioxx.tfc.api.TFCItems;
@@ -142,5 +143,11 @@ public class ItemFlintSteel extends ItemFlintAndSteel implements ISize
 	public EnumItemReach getReach(ItemStack is)
 	{
 		return EnumItemReach.SHORT;
+	}
+
+	@Override
+	public void addInformation(ItemStack is, EntityPlayer player, List arraylist, boolean flag)
+	{
+		ItemTerra.addSizeInformation(is, arraylist);
 	}
 }


### PR DESCRIPTION
added the addInformation override to include the size information for the TFC Flint and Steel.