### PR TITLE
Blast Furnace Fuel Fix

### DIFF
--- a/src/API/com/bioxx/tfc/api/Enums/EnumFuelMaterial.java
+++ b/src/API/com/bioxx/tfc/api/Enums/EnumFuelMaterial.java
@@ -20,7 +20,7 @@ public enum EnumFuelMaterial
 	KAPOK("KAPOK", 645, 1000, 			new int[]{/*Sweet*/7,/*Sour*/0,/*Salty*/0,/*Bitter*/-7,/*Savory*/0}),
 	PEAT("PEAT", 680, 2500, 			new int[]{/*Sweet*/-10,/*Sour*/0,/*Salty*/0,/*Bitter*/10,/*Savory*/0}),
 	ACACIA("ACACIA",650, 1000, 			new int[]{/*Sweet*/6,/*Sour*/6,/*Salty*/0,/*Bitter*/9,/*Savory*/-6}),
-	CHARCOAL("CHARCOAL", 1350, 1800, 	new int[]{/*Sweet*/-10,/*Sour*/8,/*Salty*/0,/*Bitter*/4,/*Savory*/15}),
+	CHARCOAL("CHARCOAL", 1400, 1875, 	new int[]{/*Sweet*/-10,/*Sour*/8,/*Salty*/0,/*Bitter*/4,/*Savory*/15}),
 	COAL("COAL", 1400, 2200, 			new int[]{/*Sweet*/-18,/*Sour*/13,/*Salty*/0,/*Bitter*/20,/*Savory*/12});
 
 	public final int burnTimeMax;

--- a/src/Common/com/bioxx/tfc/TileEntities/TEBlastFurnace.java
+++ b/src/Common/com/bioxx/tfc/TileEntities/TEBlastFurnace.java
@@ -30,6 +30,7 @@ import com.bioxx.tfc.api.Metal;
 import com.bioxx.tfc.api.TFCBlocks;
 import com.bioxx.tfc.api.TFCItems;
 import com.bioxx.tfc.api.TFC_ItemHeat;
+import com.bioxx.tfc.api.Enums.EnumFuelMaterial;
 import com.bioxx.tfc.api.Interfaces.ISmeltable;
 import com.bioxx.tfc.api.TileEntities.TEFireEntity;
 
@@ -271,8 +272,9 @@ public class TEBlastFurnace extends TEFireEntity implements IInventory
 		{
 			charcoalCount--;
 
-			fuelTimeLeft = 1875;
-			fuelBurnTemp = 1400;
+			EnumFuelMaterial m = EnumFuelMaterial.CHARCOAL;
+			fuelTimeLeft = m.burnTimeMax;
+			fuelBurnTemp = m.burnTempMax;
 		}
 		else
 		{
@@ -735,4 +737,8 @@ public class TEBlastFurnace extends TEFireEntity implements IInventory
 		worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
 	}
 
+	public int getMaxValidStackSize()
+	{
+		return maxValidStackSize;
+	}
 }


### PR DESCRIPTION
1. set charcoal values to match the values assigned by the Blast Furnace.
2. when the blast furnace uses a new charcoal, the values are returned from the Fuel enum, not hard coded.