### PR TITLE
Crucible and Alloy Fixes

### DIFF
--- a/src/Common/com/bioxx/tfc/Core/Metal/Alloy.java
+++ b/src/Common/com/bioxx/tfc/Core/Metal/Alloy.java
@@ -186,7 +186,7 @@ public class Alloy
 
 	public void toNBT(NBTTagCompound nbt)
 	{
-		nbt.setString("outputType", outputType.Name);
+		nbt.setString("outputType", outputType != null ? outputType.Name : "");
 		nbt.setFloat("outputAmount", outputAmount);
 		NBTTagList nbtlist = new NBTTagList();
 		for(int i = 0; i < AlloyIngred.size(); i++)
@@ -217,5 +217,23 @@ public class Alloy
     public EnumTier getFurnaceTier()
     {
         return furnaceTier;
+    }
+    
+    /**
+     * This provides a safe method for retrieving an Alloy - if the tag is invalid, the alloy
+     * will return as null.
+     */
+    public static Alloy loadFromNBT(NBTTagCompound nbt)
+    {
+        if (nbt == null)
+        {
+            return null;
+        }
+        
+        Alloy alloy = new Alloy();
+        alloy.fromNBT(nbt);
+        
+        // only return an alloy instance, if it is valid.
+        return (alloy.outputType != null ? alloy : null);
     }
 }

--- a/src/Common/com/bioxx/tfc/TileEntities/TECrucible.java
+++ b/src/Common/com/bioxx/tfc/TileEntities/TECrucible.java
@@ -29,6 +29,8 @@ import com.bioxx.tfc.api.Interfaces.ISmeltable;
 
 public class TECrucible extends NetworkTileEntity implements IInventory
 {
+	public static int MAX_AMOUNT = 3000;
+	
 	public HashMap<String, MetalPair> metals = new HashMap<String, MetalPair>();
 	public Alloy currentAlloy;
 	public int temperature = 0;
@@ -247,7 +249,7 @@ public class TECrucible extends NetworkTileEntity implements IInventory
 
 	public boolean addMetal(Metal m, float amt)
 	{
-		if (getTotalMetal() + amt <= 3000 && m.Name != null && m.Name != "Unknown")
+		if (getTotalMetal() + amt <= MAX_AMOUNT && m.Name != null && m.Name != "Unknown")
 		{
 			if(metals.containsKey(m.Name))
 				((MetalPair)metals.get(m.Name)).amount += amt;
@@ -388,7 +390,7 @@ public class TECrucible extends NetworkTileEntity implements IInventory
 	public int getOutCountScaled(int length)
 	{
 		if(currentAlloy != null)
-			return ((int)this.currentAlloy.outputAmount * length)/3000;
+			return ((int)this.currentAlloy.outputAmount * length)/MAX_AMOUNT;
 		else
 			return 0;
 	}
@@ -425,7 +427,7 @@ public class TECrucible extends NetworkTileEntity implements IInventory
 	public void handleDataPacket(NBTTagCompound nbt) {
 		byte action = nbt.getByte("action");
 		if(action == 0)
-			this.currentAlloy = new Alloy().fromNBT(nbt);
+			this.currentAlloy = Alloy.loadFromNBT(nbt);
 		else if(action == 1 && currentAlloy != null)
 		{
 			currentAlloy.outputAmount = nbt.getFloat("outputAmount");


### PR DESCRIPTION
1. Alloy - added a safe method for retrieving an Alloy - if the tag is invalid, the alloy will return as null.
2. Crucible - added a constants for maximum amount 
3. Crucible - implemented the safe call for the alloy. When opening the GUI for a crucible that does not contain anything, nothing is shown is the main area (unlike now, it says Unknown).