### PR TITLE
Custom Barrel Preservatives API (pt2)

### DIFF
--- a/src/API/com/bioxx/tfc/api/Crafting/BarrelManager.java
+++ b/src/API/com/bioxx/tfc/api/Crafting/BarrelManager.java
@@ -3,6 +3,8 @@ package com.bioxx.tfc.api.Crafting;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.bioxx.tfc.TileEntities.TEBarrel;
+
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
@@ -15,15 +17,21 @@ public class BarrelManager
 	}
 
 	private List<BarrelRecipe> recipes;
+	private List<BarrelPreservativeRecipe> preservativeRecipes;
 
 	private BarrelManager()
 	{
 		recipes = new ArrayList<BarrelRecipe>();
+		preservativeRecipes = new ArrayList<BarrelPreservativeRecipe>();
 	}
 
 	public void addRecipe(BarrelRecipe recipe)
 	{
 		recipes.add(recipe);
+	}
+	
+	public void addPreservative(BarrelPreservativeRecipe recipe) {
+		preservativeRecipes.add(recipe);
 	}
 
 	public BarrelRecipe findMatchingRecipe(ItemStack item, FluidStack fluid, boolean sealed, int techLevel)
@@ -37,9 +45,25 @@ public class BarrelManager
 		}
 		return null;
 	}
+	
+	public BarrelPreservativeRecipe findMatchingPreservativeRepice(TEBarrel barrel, ItemStack item, FluidStack fluid, boolean sealed)
+	{
+		for(BarrelPreservativeRecipe recipe : preservativeRecipes){
+			if(recipe.checkForPreservation(barrel, fluid, item, sealed))
+				return recipe;
+		}
+		return null;
+	}
 
 	public List<BarrelRecipe> getRecipes()
 	{
 		return recipes;
 	}
+	
+	public List<BarrelPreservativeRecipe> getPreservatives()
+	{
+		return preservativeRecipes;
+	}
+
+
 }

--- a/src/API/com/bioxx/tfc/api/Crafting/BarrelPreservativeRecipe.java
+++ b/src/API/com/bioxx/tfc/api/Crafting/BarrelPreservativeRecipe.java
@@ -1,0 +1,207 @@
+package com.bioxx.tfc.api.Crafting;
+
+import com.bioxx.tfc.TileEntities.TEBarrel;
+import com.bioxx.tfc.api.Food;
+import com.bioxx.tfc.api.Enums.EnumFoodGroup;
+import com.bioxx.tfc.api.Interfaces.IFood;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+
+public class BarrelPreservativeRecipe {
+	private boolean requiresBrined = false;
+	private boolean requiresPickled = false;
+	private boolean requiresSalted = false;
+	private boolean requiresDried = false;
+	private boolean requiresSmoked = false;
+	private boolean requiresInfused = false;
+	
+	private boolean requiresSealed = false;
+	
+	private boolean allowGrains = true;
+	private boolean allowProteins = true;
+	private boolean allowVegetables = true;
+	private boolean allowFruit = true;
+	private boolean allowDairy = true;
+	
+	private FluidStack liquidPerOz = null;
+	
+	private float environmentalDecayFactor = -1;
+	private float baseDecayModifier = -1;
+	private String preservingString;
+	
+	/***
+	 * Checks a barrel to see if it should be preserving. Allows Overriding this function in subclass
+	 * @param xCoord
+	 * @param yCoord
+	 * @param zCoord
+	 * @param fluid
+	 * @param itemStack
+	 * @param sealed
+	 * @return
+	 */
+	public boolean checkForPreservation(TEBarrel barrel, FluidStack fluid, ItemStack itemStack, boolean sealed){
+		if(itemStack == null || fluid == null)
+		{ 
+			return false; 
+		}
+		if(!(itemStack.getItem() instanceof IFood))
+		{
+			return false;
+		}
+		if(fluid.getFluid() != liquidPerOz.getFluid())
+		{
+			return false;
+		}
+		IFood iFood = ((IFood)itemStack.getItem());
+		float w = iFood.getFoodWeight(itemStack);
+		if(!allowGrains && iFood.getFoodGroup() == EnumFoodGroup.Grain)
+		{
+			return false;
+		}
+		if(!allowProteins && iFood.getFoodGroup() == EnumFoodGroup.Protein)
+		{
+			return false;
+		}
+		if(!allowFruit && iFood.getFoodGroup() == EnumFoodGroup.Fruit)
+		{
+			return false;
+		}
+		if(!allowVegetables && iFood.getFoodGroup() == EnumFoodGroup.Vegetable)
+		{
+			return false;
+		}
+		if(!allowDairy && iFood.getFoodGroup() == EnumFoodGroup.Dairy)
+		{
+			return false;
+		}
+		if(requiresBrined && !Food.isBrined(itemStack))
+		{
+			return false;
+		}
+		if(requiresPickled && !Food.isPickled(itemStack))
+		{
+			return false;
+		}
+		if(requiresSalted && !Food.isSalted(itemStack))
+		{
+			return false;
+		}
+		if(requiresDried && !Food.isDried(itemStack))
+		{
+			return false;
+		}
+		if(requiresSmoked && !Food.isSmoked(itemStack))
+		{
+			return false;
+		}
+		if(requiresInfused && !Food.isInfused(itemStack))
+		{
+			return false;
+		}
+		if(requiresSealed && !sealed)
+		{
+			return false;
+		}
+		if(liquidPerOz.amount * w > fluid.amount){
+			return false;
+		}
+		return true;
+	}
+	
+	public BarrelPreservativeRecipe(FluidStack liquidPerOz, String unlocalizedPreservingLabel){
+		this.liquidPerOz = liquidPerOz;
+		this.preservingString = unlocalizedPreservingLabel;
+	}
+	
+	public BarrelPreservativeRecipe setRequiresBrined(boolean b)
+	{
+		requiresBrined = b;
+		return this;
+	}
+	
+	public BarrelPreservativeRecipe setRequiresPickled(boolean b)
+	{
+		requiresPickled = b;
+		return this;
+	}
+	
+	public BarrelPreservativeRecipe setRequiresSalted(boolean b)
+	{
+		requiresSalted = b;
+		return this;
+	}
+	
+	public BarrelPreservativeRecipe setRequiresDried(boolean b)
+	{
+		requiresDried = b;
+		return this;
+	}
+	
+	public BarrelPreservativeRecipe setRequiresSmoked(boolean b)
+	{
+		requiresSmoked = b;
+		return this;
+	}
+	
+	public BarrelPreservativeRecipe setRequiresInfused(boolean b)
+	{
+		requiresInfused = b;
+		return this;
+	}
+	
+	public BarrelPreservativeRecipe setRequiresSealed(boolean b)
+	{
+		requiresSealed = b;
+		return this;
+	}
+	
+	public BarrelPreservativeRecipe setAllowProtien(boolean b){
+		allowProteins = b;
+		return this;
+	}
+	
+	public BarrelPreservativeRecipe setAllowGrains(boolean b){
+		allowGrains = b;
+		return this;
+	}
+	
+	public BarrelPreservativeRecipe setAllowFruit(boolean b){
+		allowFruit = b;
+		return this;
+	}
+	
+	public BarrelPreservativeRecipe setAllowVegetable(boolean b){
+		allowVegetables = b;
+		return this;
+	}
+	
+	public BarrelPreservativeRecipe setAllowDairy(boolean b){
+		allowDairy = b;
+		return this;
+	}
+
+	public BarrelPreservativeRecipe setEnvironmentalDecayFactor(float rate) {
+		environmentalDecayFactor = rate;
+		return this;
+	}
+
+	public BarrelPreservativeRecipe setBaseDecayModifier(float rate) {
+		baseDecayModifier = rate;
+		return this;
+	}
+	
+	
+	public float getEnvironmentalDecayFactor(){
+		return environmentalDecayFactor;
+	}
+	
+	public float getBaseDecayModifier(){
+		return baseDecayModifier;
+	}
+
+	public String getPreservingString() {
+		return preservingString;
+	}
+
+}

--- a/src/Common/com/bioxx/tfc/GUI/GuiBarrel.java
+++ b/src/Common/com/bioxx/tfc/GUI/GuiBarrel.java
@@ -30,6 +30,8 @@ import com.bioxx.tfc.api.TFCFluids;
 import com.bioxx.tfc.api.TFCItems;
 import com.bioxx.tfc.api.Constant.Global;
 import com.bioxx.tfc.api.Crafting.BarrelBriningRecipe;
+import com.bioxx.tfc.api.Crafting.BarrelManager;
+import com.bioxx.tfc.api.Crafting.BarrelPreservativeRecipe;
 import com.bioxx.tfc.api.Enums.EnumFoodGroup;
 import com.bioxx.tfc.api.Interfaces.IFood;
 
@@ -339,20 +341,20 @@ public class GuiBarrel extends GuiContainerTFC
 				}
 			}
 			else if (barrelTE.recipe == null && barrelTE.getSealed() && barrelTE.getFluidStack() != null && inStack != null && inStack.getItem() instanceof IFood &&
-					barrelTE.getFluidStack().getFluid() == TFCFluids.VINEGAR)
+					barrelTE.getFluidStack().getFluid() == TFCFluids.VINEGAR && !Food.isPickled(inStack) && Food.getWeight(inStack) / barrelTE.getFluidStack().amount <= Global.FOOD_MAX_WEIGHT / barrelTE.getMaxLiquid())
 			{
-				if (!Food.isPickled(inStack) && Food.getWeight(inStack) / barrelTE.getFluidStack().amount <= Global.FOOD_MAX_WEIGHT / barrelTE.getMaxLiquid())
+				if ((((IFood) inStack.getItem()).getFoodGroup() == EnumFoodGroup.Fruit || ((IFood) inStack.getItem()).getFoodGroup() == EnumFoodGroup.Vegetable ||
+						((IFood) inStack.getItem()).getFoodGroup() == EnumFoodGroup.Protein || ((IFood) inStack.getItem()) == TFCItems.Cheese) &&
+						Food.isBrined(inStack))
 				{
-					if ((((IFood) inStack.getItem()).getFoodGroup() == EnumFoodGroup.Fruit || ((IFood) inStack.getItem()).getFoodGroup() == EnumFoodGroup.Vegetable ||
-							((IFood) inStack.getItem()).getFoodGroup() == EnumFoodGroup.Protein || ((IFood) inStack.getItem()) == TFCItems.Cheese) &&
-							Food.isBrined(inStack))
-					{
-						drawCenteredString(this.fontRendererObj, StatCollector.translateToLocal("gui.barrel.pickling"), guiLeft + 88, guiTop + 72, 0x555555);
-					}
+					drawCenteredString(this.fontRendererObj, StatCollector.translateToLocal("gui.barrel.pickling"), guiLeft + 88, guiTop + 72, 0x555555);
 				}
-				else if (Food.isPickled(inStack) && Food.getWeight(inStack) / barrelTE.getFluidStack().amount <= Global.FOOD_MAX_WEIGHT / barrelTE.getMaxLiquid() * 2)
-				{
-					drawCenteredString(this.fontRendererObj, StatCollector.translateToLocal("gui.barrel.preserving"), guiLeft + 88, guiTop + 72, 0x555555);
+			}
+			else
+			{
+				BarrelPreservativeRecipe preservative = BarrelManager.getInstance().findMatchingPreservativeRepice(barrelTE, inStack, barrelTE.getFluidStack(), barrelTE.getSealed());
+				if(preservative!=null){
+					drawCenteredString(this.fontRendererObj, StatCollector.translateToLocal(preservative.getPreservingString()), guiLeft+88, guiTop+72, 0x555555);
 				}
 			}
 

--- a/src/Common/com/bioxx/tfc/GUI/GuiLargeVessel.java
+++ b/src/Common/com/bioxx/tfc/GUI/GuiLargeVessel.java
@@ -31,6 +31,8 @@ import com.bioxx.tfc.api.TFCFluids;
 import com.bioxx.tfc.api.TFCItems;
 import com.bioxx.tfc.api.Constant.Global;
 import com.bioxx.tfc.api.Crafting.BarrelBriningRecipe;
+import com.bioxx.tfc.api.Crafting.BarrelManager;
+import com.bioxx.tfc.api.Crafting.BarrelPreservativeRecipe;
 import com.bioxx.tfc.api.Enums.EnumFoodGroup;
 import com.bioxx.tfc.api.Interfaces.IFood;
 
@@ -340,20 +342,20 @@ public class GuiLargeVessel extends GuiContainerTFC
 				}
 			}
 			else if (vesselTE.recipe == null && vesselTE.getSealed() && vesselTE.getFluidStack() != null && inStack != null && inStack.getItem() instanceof IFood &&
-					vesselTE.getFluidStack().getFluid() == TFCFluids.VINEGAR)
+					vesselTE.getFluidStack().getFluid() == TFCFluids.VINEGAR && !Food.isPickled(inStack) && Food.getWeight(inStack) / vesselTE.getFluidStack().amount <= Global.FOOD_MAX_WEIGHT / vesselTE.getMaxLiquid())
 			{
-				if (!Food.isPickled(inStack) && Food.getWeight(inStack) / vesselTE.getFluidStack().amount <= Global.FOOD_MAX_WEIGHT / vesselTE.getMaxLiquid())
+				if ((((IFood) inStack.getItem()).getFoodGroup() == EnumFoodGroup.Fruit || ((IFood) inStack.getItem()).getFoodGroup() == EnumFoodGroup.Vegetable ||
+						((IFood) inStack.getItem()).getFoodGroup() == EnumFoodGroup.Protein || ((IFood) inStack.getItem()) == TFCItems.Cheese) &&
+						Food.isBrined(inStack))
 				{
-					if ((((IFood) inStack.getItem()).getFoodGroup() == EnumFoodGroup.Fruit || ((IFood) inStack.getItem()).getFoodGroup() == EnumFoodGroup.Vegetable ||
-							((IFood) inStack.getItem()).getFoodGroup() == EnumFoodGroup.Protein || ((IFood) inStack.getItem()) == TFCItems.Cheese) &&
-							Food.isBrined(inStack))
-					{
-						drawCenteredString(this.fontRendererObj, StatCollector.translateToLocal("gui.barrel.pickling"), guiLeft + 88, guiTop + 72, 0x555555);
-					}
+					drawCenteredString(this.fontRendererObj, StatCollector.translateToLocal("gui.barrel.pickling"), guiLeft + 88, guiTop + 72, 0x555555);
 				}
-				else if (Food.isPickled(inStack) && Food.getWeight(inStack) / vesselTE.getFluidStack().amount <= Global.FOOD_MAX_WEIGHT / vesselTE.getMaxLiquid() * 2)
-				{
-					drawCenteredString(this.fontRendererObj, StatCollector.translateToLocal("gui.barrel.preserving"), guiLeft + 88, guiTop + 72, 0x555555);
+			}
+			else
+			{
+				BarrelPreservativeRecipe preservative = BarrelManager.getInstance().findMatchingPreservativeRepice(vesselTE, inStack, vesselTE.getFluidStack(), vesselTE.getSealed());
+				if(preservative!=null){
+					drawCenteredString(this.fontRendererObj, StatCollector.translateToLocal(preservative.getPreservingString()), guiLeft+88, guiTop+72, 0x555555);
 				}
 			}
 		}

--- a/src/Common/com/bioxx/tfc/TileEntities/TEBarrel.java
+++ b/src/Common/com/bioxx/tfc/TileEntities/TEBarrel.java
@@ -2,6 +2,8 @@ package com.bioxx.tfc.TileEntities;
 
 import java.util.Random;
 
+import scala.collection.script.End;
+
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Items;
@@ -29,6 +31,7 @@ import com.bioxx.tfc.api.Crafting.BarrelBriningRecipe;
 import com.bioxx.tfc.api.Crafting.BarrelLiquidToLiquidRecipe;
 import com.bioxx.tfc.api.Crafting.BarrelManager;
 import com.bioxx.tfc.api.Crafting.BarrelMultiItemRecipe;
+import com.bioxx.tfc.api.Crafting.BarrelPreservativeRecipe;
 import com.bioxx.tfc.api.Crafting.BarrelRecipe;
 import com.bioxx.tfc.api.Crafting.BarrelVinegarRecipe;
 import com.bioxx.tfc.api.Enums.EnumFoodGroup;
@@ -580,11 +583,8 @@ public class TEBarrel extends NetworkTileEntity implements IInventory
 	{
 		if(!worldObj.isRemote)
 		{
-			DecayTickType decayTickType = DecayTickType.Standard;
 			ItemStack itemstack = storage[0]; 
-			float liquidToFoodRatioBrine = Global.FOOD_MAX_WEIGHT/10000f;//0.016
-			float liquidToFoodRatioVinegar = Global.FOOD_MAX_WEIGHT/5000f;//0.032
-
+			BarrelPreservativeRecipe preservative = BarrelManager.getInstance().findMatchingPreservativeRepice(this, itemstack, fluid, sealed);
 			if (itemstack != null && fluid != null && fluid.getFluid() == TFCFluids.FRESHWATER)
 			{
 				if(TFC_ItemHeat.HasTemp(itemstack))
@@ -602,16 +602,7 @@ public class TEBarrel extends NetworkTileEntity implements IInventory
 			if(fluid != null && itemstack != null && itemstack.getItem() instanceof IFood)
 			{
 				float w = ((IFood)itemstack.getItem()).getFoodWeight(itemstack);
-				if(fluid.getFluid() == TFCFluids.BRINE)
-				{
-					if(Food.isBrined(itemstack))
-					{
-						//Do a calculation to see if there is enough Brine here to cover the food. If there is then we perform our non-standard decay tick.
-						if(w/fluid.amount <= liquidToFoodRatioBrine)
-							decayTickType = DecayTickType.Brine;
-					}
-				}
-				else if(fluid.getFluid() == TFCFluids.VINEGAR)
+				if(fluid.getFluid() == TFCFluids.VINEGAR)
 				{
 					//If the food is brined then we attempt to pickle it
 					if(Food.isBrined(itemstack) && !Food.isPickled(itemstack) && w/fluid.amount <= Global.FOOD_MAX_WEIGHT/this.getMaxLiquid() && this.getSealed() &&
@@ -620,27 +611,30 @@ public class TEBarrel extends NetworkTileEntity implements IInventory
 						fluid.amount -= 1 * w;
 						Food.setPickled(itemstack, true);
 					}
-					//Do a calculation to see if there is enough Vinegar here to cover the food. If there is and the item has been properly pickled 
-					//then we perform our non-standard decay tick. If the food is in the process of pickling then we decay as if we were in brine.
-					if(Food.isPickled(itemstack) && w/fluid.amount <= liquidToFoodRatioVinegar)
-						decayTickType = DecayTickType.Vinegar;
-					else if(Food.isBrined(itemstack) && w/fluid.amount <= liquidToFoodRatioBrine)
-						decayTickType = DecayTickType.Brine;
 				}
 			}
 
-
-			if(decayTickType == DecayTickType.Standard)
+			if(preservative == null)
 			{
+				// No preservative was matched - decay normally
 				TFC_Core.handleItemTicking(this, this.worldObj, xCoord, yCoord, zCoord);
 			}
-			else if(decayTickType == DecayTickType.Brine)
+			else
 			{
-				TFC_Core.handleItemTicking(this, this.worldObj, xCoord, yCoord, zCoord, 0.75f);
-			}
-			else if(decayTickType == DecayTickType.Vinegar)
-			{
-				TFC_Core.handleItemTicking(this, this.worldObj, xCoord, yCoord, zCoord, 0.25f, 0.1f);
+				float env = preservative.getEnvironmentalDecayFactor();
+				float base = preservative.getBaseDecayModifier();
+				if(Float.isNaN(env) || env < 0.0)
+				{
+					TFC_Core.handleItemTicking(this, this.worldObj, xCoord, yCoord, zCoord);
+				}
+				else if(Float.isNaN(base) || base < 0.0)
+				{
+					TFC_Core.handleItemTicking(this, this.worldObj, xCoord, yCoord, zCoord, env);
+				}
+				else
+				{
+					TFC_Core.handleItemTicking(this, this.worldObj, xCoord, yCoord, zCoord, env, base);
+				}
 			}
 
 			//If lightning can strike here then it means that the barrel can see the sky, so rain can hit it. If true then we fill
@@ -913,7 +907,7 @@ public class TEBarrel extends NetworkTileEntity implements IInventory
 		BarrelManager.getInstance().addRecipe(new BarrelVinegarRecipe(new FluidStack(TFCFluids.CIDER, 100), new FluidStack(TFCFluids.VINEGAR, 100)));
 		BarrelManager.getInstance().addRecipe(new BarrelVinegarRecipe(new FluidStack(TFCFluids.WHISKEY, 100), new FluidStack(TFCFluids.VINEGAR, 100)));
 		BarrelManager.getInstance().addRecipe(new BarrelVinegarRecipe(new FluidStack(TFCFluids.RYEWHISKEY, 100), new FluidStack(TFCFluids.VINEGAR, 100)));
-		BarrelManager.getInstance().addRecipe(new BarrelVinegarRecipe(new FluidStack(TFCFluids.BEER, 100), new FluidStack(TFCFluids.VINEGAR, 100)));
+		BarrelManager.getInstance().addRecipe(new BarrelVinegarRecipe(new FluidStack(TFCFluids.BEER, 100), new FluidStack(TFCFluids.VINEGAR, 100)));	
 		BarrelManager.getInstance().addRecipe(new BarrelVinegarRecipe(new FluidStack(TFCFluids.SAKE, 100), new FluidStack(TFCFluids.VINEGAR, 100)));
 		BarrelManager.getInstance().addRecipe(new BarrelVinegarRecipe(new FluidStack(TFCFluids.RUM, 100), new FluidStack(TFCFluids.VINEGAR, 100)));
 		BarrelManager.getInstance().addRecipe(new BarrelVinegarRecipe(new FluidStack(TFCFluids.CORNWHISKEY, 100), new FluidStack(TFCFluids.VINEGAR, 100)));
@@ -923,12 +917,14 @@ public class TEBarrel extends NetworkTileEntity implements IInventory
 		BarrelManager.getInstance().addRecipe(new BarrelMultiItemRecipe(new ItemStack(TFCItems.Jute, 1, 0), new FluidStack(TFCFluids.FRESHWATER, 200), new ItemStack(TFCItems.JuteFibre, 1, 0), new FluidStack(TFCFluids.FRESHWATER, 200)).setMinTechLevel(0));
 		BarrelManager.getInstance().addRecipe(new BarrelLiquidToLiquidRecipe(new FluidStack(TFCFluids.MILK, 9000), new FluidStack(TFCFluids.VINEGAR, 1000), new FluidStack(TFCFluids.MILKVINEGAR, 10000)).setSealedRecipe(false).setMinTechLevel(0).setRemovesLiquid(false));
 		BarrelManager.getInstance().addRecipe(new BarrelLiquidToLiquidRecipe(new FluidStack(TFCFluids.MILKVINEGAR, 9000), new FluidStack(TFCFluids.MILK, 1000), new FluidStack(TFCFluids.MILKVINEGAR, 10000)).setSealedRecipe(false).setMinTechLevel(0).setRemovesLiquid(false));
-	}
-
-	private enum DecayTickType
-	{
-		Standard,
-		Brine,
-		Vinegar;
+		// 5000mb / 160oz = 31.25
+		// 10000mb / 160oz = 62.5
+		// FluidStack naturally only takes int so I rounded down
+		BarrelPreservativeRecipe picklePreservative = new BarrelPreservativeRecipe(new FluidStack(TFCFluids.VINEGAR,31),"gui.barrel.preserving").setAllowGrains(false).setRequiresPickled(true).setEnvironmentalDecayFactor(0.25f).setBaseDecayModifier(0.1f).setRequiresSealed(true);
+		BarrelPreservativeRecipe brineInBrinePreservative = new BarrelPreservativeRecipe(new FluidStack(TFCFluids.BRINE,62),"gui.barrel.preserving").setAllowGrains(false).setRequiresBrined(true).setEnvironmentalDecayFactor(0.75f).setRequiresSealed(true);
+		BarrelPreservativeRecipe brineInVinegarPreservative = new BarrelPreservativeRecipe(new FluidStack(TFCFluids.VINEGAR,62),"gui.barrel.preserving").setAllowGrains(false).setRequiresBrined(true).setEnvironmentalDecayFactor(0.75f).setRequiresSealed(true);
+		BarrelManager.getInstance().addPreservative(picklePreservative);
+		BarrelManager.getInstance().addPreservative(brineInBrinePreservative);
+		BarrelManager.getInstance().addPreservative(brineInVinegarPreservative);
 	}
 }

--- a/src/Common/com/bioxx/tfc/WAILA/WAILADataTE.java
+++ b/src/Common/com/bioxx/tfc/WAILA/WAILADataTE.java
@@ -58,6 +58,7 @@ import com.bioxx.tfc.api.TFC_ItemHeat;
 import com.bioxx.tfc.api.Constant.Global;
 import com.bioxx.tfc.api.Crafting.BarrelBriningRecipe;
 import com.bioxx.tfc.api.Crafting.BarrelManager;
+import com.bioxx.tfc.api.Crafting.BarrelPreservativeRecipe;
 import com.bioxx.tfc.api.Crafting.BarrelRecipe;
 import com.bioxx.tfc.api.Crafting.LoomManager;
 import com.bioxx.tfc.api.Crafting.LoomRecipe;
@@ -503,7 +504,11 @@ public class WAILADataTE implements IWailaDataProvider
 			currenttip.add(TFC_Core.translate("gui.Barrel.SealedOn") + " : " + TFC_Time.getDateStringFromHours(sealTime));
 		}
 
+		
 		// Output
+		BarrelPreservativeRecipe preservative = BarrelManager.getInstance().findMatchingPreservativeRepice(te, inStack, fluid, sealed);
+
+		
 		if (recipe != null)
 		{
 			if (!(recipe instanceof BarrelBriningRecipe))
@@ -531,6 +536,8 @@ public class WAILADataTE implements IWailaDataProvider
 			{
 				currenttip.add(TFC_Core.translate("gui.barrel.preserving"));
 			}
+		}else if(preservative!=null){
+			currenttip.add(TFC_Core.translate(preservative.getPreservingString()));
 		}
 
 		return currenttip;


### PR DESCRIPTION
- Removed hardcoded preservation from Barrel and Large Vessel
- Added BarrelPreservationRecipe which can be set up for basic liquid preservation of food. Can be overriden to provide other preservation methods
- Reimplemented Brine and Vinegar preservation with the new API.
- Fixed WAILA output to show custom preservatives