### PR TITLE
Added DYE_NAMES (for small vessel and carpets) to Global,

### DIFF
--- a/src/API/com/bioxx/tfc/api/Constant/Global.java
+++ b/src/API/com/bioxx/tfc/api/Constant/Global.java
@@ -31,6 +31,14 @@ public class Global
 		"Flux", "Kaolinite Powder", "Graphite Powder", "Sulfur Powder", "Saltpeter Powder",
 		"Hematite Powder", "Lapis Lazuli Powder", "Limonite Powder", "Malachite Powder", "Salt"
 	};
+	
+	/* Dyes, used for carpets and small vessels */
+	/* Colors MUST be in the same order as in EntitySheep.fleeceColorTable! */
+	public static final String[] DYE_NAMES = { 
+		"dyeWhite", "dyeOrange", "dyeMagenta", "dyeLightBlue", "dyeYellow",
+		"dyeLime", "dyePink", "dyeGray", "dyeLightGray", "dyeCyan", 
+		"dyePurple", "dyeBlue", "dyeBrown", "dyeGreen", "dyeRed", "dyeBlack" };
+
 
 	/* Stone Types */
 	public static final String[] STONE_IGIN = {"Granite", "Diorite", "Gabbro"};

--- a/src/Common/com/bioxx/tfc/Core/Recipes.java
+++ b/src/Common/com/bioxx/tfc/Core/Recipes.java
@@ -192,11 +192,9 @@ public class Recipes
 		GameRegistry.addRecipe(new ItemStack(TFCItems.GlassBottle, 3), new Object[]
 				{ "# #", " # ", Character.valueOf('#'), new ItemStack(Blocks.glass) });
 
-		String[] dyes =
-			{ "White", "Orange", "Magenta", "LightBlue", "Yellow", "Lime", "Pink", "Gray", "LightGray", "Cyan", "Purple", "Blue", "Brown", "Green", "Red", "Black" };
-		for (int i = 0; i < dyes.length; i++)
+		for (int i = 0; i < Global.DYE_NAMES.length; i++)
 		{
-			GameRegistry.addRecipe(new ShapelessOreRecipe(new ItemStack(Blocks.carpet, 1, i), "dye" + dyes[i], new ItemStack(Blocks.carpet, 1, WILD)));
+			GameRegistry.addRecipe(new ShapelessOreRecipe(new ItemStack(Blocks.carpet, 1, i), Global.DYE_NAMES[i], new ItemStack(Blocks.carpet, 1, WILD)));
 		}
 
 		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(Blocks.rail, 64), new Object[] { "PsP","PsP", Character.valueOf('P'), "ingotIron", Character.valueOf('s'), "stickWood"}));
@@ -430,9 +428,10 @@ public class Recipes
 		GameRegistry.addShapelessRecipe(new ItemStack(TFCItems.UnknownIngot, 1, 0), 
 				new Object[] {getStackNoTemp(new ItemStack(TFCItems.UnknownUnshaped, 1))});
 
-		for(int i = 0; i < 16; i++)
+		for(int i = 0; i < Global.DYE_NAMES.length; i++)
 		{
-			GameRegistry.addRecipe(new ShapelessOreRecipe(new ItemStack(TFCItems.PotterySmallVessel, 1, 0), new Object[] { new ItemStack(TFCItems.PotterySmallVessel, 1, 0), "dye"+dyes[i] }));
+			GameRegistry.addRecipe(new ShapelessOreRecipe(new ItemStack(TFCItems.PotterySmallVessel, 1, 0), 
+					new Object[] { new ItemStack(TFCItems.PotterySmallVessel, 1, 0), Global.DYE_NAMES[i] }));
 		}
 
 		RegisterToolRecipes();

--- a/src/Common/com/bioxx/tfc/Handlers/CraftingHandler.java
+++ b/src/Common/com/bioxx/tfc/Handlers/CraftingHandler.java
@@ -28,6 +28,7 @@ import com.bioxx.tfc.Items.Tools.ItemMiscToolHead;
 import com.bioxx.tfc.api.TFCBlocks;
 import com.bioxx.tfc.api.TFCItems;
 import com.bioxx.tfc.api.TFC_ItemHeat;
+import com.bioxx.tfc.api.Constant.Global;
 import com.bioxx.tfc.api.Crafting.AnvilManager;
 
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
@@ -192,8 +193,6 @@ public class CraftingHandler
 			}
 			else if(itemstack.getItem() == TFCItems.PotterySmallVessel && itemstack.getItemDamage() == 0)
 			{
-				String[] dyes =
-					{ "White", "Orange", "Magenta", "LightBlue", "Yellow", "Lime", "Pink", "Gray", "LightGray", "Cyan", "Purple", "Blue", "Brown", "Green", "Red", "Black" };
 				int color = -1;
 				for(int i = 0; i < iinventory.getSizeInventory(); i++)
 				{
@@ -205,38 +204,14 @@ public class CraftingHandler
 					for(int id : ids)
 					{
 						String name = OreDictionary.getOreName(id);
-						if(name.equals("dyeWhite"))
-							c = EntitySheep.fleeceColorTable[0];
-						else if(name.equals("dyeOrange"))
-							c = EntitySheep.fleeceColorTable[1];
-						else if(name.equals("dyeMagenta"))
-							c = EntitySheep.fleeceColorTable[2];
-						else if(name.equals("dyeLightBlue"))
-							c = EntitySheep.fleeceColorTable[3];
-						else if(name.equals("dyeYellow"))
-							c = EntitySheep.fleeceColorTable[4];
-						else if(name.equals("dyeLime"))
-							c = EntitySheep.fleeceColorTable[5];
-						else if(name.equals("dyePink"))
-							c = EntitySheep.fleeceColorTable[6];
-						else if(name.equals("dyeGray"))
-							c = EntitySheep.fleeceColorTable[7];
-						else if(name.equals("dyeLightGray"))
-							c = EntitySheep.fleeceColorTable[8];
-						else if(name.equals("dyeCyan"))
-							c = EntitySheep.fleeceColorTable[9];
-						else if(name.equals("dyePurple"))
-							c = EntitySheep.fleeceColorTable[10];
-						else if(name.equals("dyeBlue"))
-							c = EntitySheep.fleeceColorTable[11];
-						else if(name.equals("dyeBrown"))
-							c = EntitySheep.fleeceColorTable[12];
-						else if(name.equals("dyeGreen"))
-							c = EntitySheep.fleeceColorTable[13];
-						else if(name.equals("dyeRed"))
-							c = EntitySheep.fleeceColorTable[14];
-						else if(name.equals("dyeBlack"))
-							c = EntitySheep.fleeceColorTable[15];
+						for(int j = 1; j < Global.DYE_NAMES.length; j++)
+						{
+							if (name.equals(Global.DYE_NAMES[j]))
+							{
+								c = EntitySheep.fleeceColorTable[j];
+								break;
+							}
+						}
 					}
 
 					if(c != null)
@@ -244,17 +219,15 @@ public class CraftingHandler
 						int r = (int)(c[0]*255);
 						int g = (int)(c[1]*255);
 						int b = (int)(c[2]*255);
-						r = r << 16;
-						g = g << 8;
 
-						color += r += g += b;
+						color = (r << 16) + (g << 8) + b;
 					}
 
 				}
 
 				if(color != -1)
 				{
-					NBTTagCompound nbt = null;
+					NBTTagCompound nbt;
 					if(itemstack.hasTagCompound())
 						nbt = itemstack.getTagCompound();
 					else


### PR DESCRIPTION
not sure if Global is the best place;

made Small Vessel coloring code more readable (hopefully);

removed eventual bug if coloring with pitch dark black dye (0,0,0) - adding zero to -1 is still -1 -> no color
should not happen since MC black is (0.1,0.1,0.1),
but done it since I had already touched the file...