### PR TITLE
Add sluice overworking config options

### DIFF
--- a/src/API/com/bioxx/tfc/api/TFCOptions.java
+++ b/src/API/com/bioxx/tfc/api/TFCOptions.java
@@ -65,6 +65,10 @@ public class TFCOptions
 	public static int poorOreUnits = 15;
 	public static int normalOreUnits = 25;
 	public static int richOreUnits = 35;
+	
+	public static boolean enableSluiceOverworking = true;
+	public static int goldPanSluicingLimit = 50;
+	public static int sluiceSluicingLimit = 300;
 
 	public static String quiverHUDPosition = "bottomleft";
 

--- a/src/Common/com/bioxx/tfc/Items/Tools/ItemGoldPan.java
+++ b/src/Common/com/bioxx/tfc/Items/Tools/ItemGoldPan.java
@@ -23,6 +23,7 @@ import com.bioxx.tfc.Core.Player.SkillStats.SkillRank;
 import com.bioxx.tfc.Items.ItemTerra;
 import com.bioxx.tfc.api.TFCBlocks;
 import com.bioxx.tfc.api.TFCItems;
+import com.bioxx.tfc.api.TFCOptions;
 import com.bioxx.tfc.api.Constant.Global;
 import com.bioxx.tfc.api.Enums.EnumItemReach;
 import com.bioxx.tfc.api.Enums.EnumSize;
@@ -116,7 +117,7 @@ public class ItemGoldPan extends ItemTerra
 						return is;
 					}
 
-					if(cd.sluicedAmount < 50)
+					if(cd.sluicedAmount < TFCOptions.goldPanSluicingLimit || !TFCOptions.enableSluiceOverworking)
 					{
 						if (blockHit == TFCBlocks.Gravel || blockHit == TFCBlocks.Gravel2)
 						{

--- a/src/Common/com/bioxx/tfc/TerraFirmaCraft.java
+++ b/src/Common/com/bioxx/tfc/TerraFirmaCraft.java
@@ -98,6 +98,7 @@ public class TerraFirmaCraft
 	private static final String PROTECTION_HEADER = "Protection";
 	private static final String PLAYER_HEADER = "Player";
 	private static final String MATERIALS_HEADER = "Materials";
+	private static final String SLUICING_HEADER = "Sluicing";
 	private static final String SERVER_HEADER = "Server";
 	
 	@Instance("TerraFirmaCraft")
@@ -411,6 +412,11 @@ public class TerraFirmaCraft
 		TFCOptions.poorOreUnits = TFCOptions.getIntFor(config, MATERIALS_HEADER, "poorOreUnits", 15, "The metal units provided by a single piece of poor ore.");
 		TFCOptions.normalOreUnits = TFCOptions.getIntFor(config, MATERIALS_HEADER, "normalOreUnits", 25, "The metal units provided by a single piece of normal ore.");
 		TFCOptions.richOreUnits = TFCOptions.getIntFor(config, MATERIALS_HEADER, "richOreUnits", 35, "The metal units provided by a single piece of rich ore");
+
+		//Sluicing
+		TFCOptions.enableSluiceOverworking = TFCOptions.getBooleanFor(config, SLUICING_HEADER, "enableSluiceOverworking", true, "Whether a given chunk can become overworked and unusable for sluicing. (Default true)");
+		TFCOptions.goldPanSluicingLimit = TFCOptions.getIntFor(config, SLUICING_HEADER, "goldPanSluicingLimit", 50, "How many times a gold pan can be used in a chunk before it is overworked. (Default 50)");
+		TFCOptions.sluiceSluicingLimit = TFCOptions.getIntFor(config, SLUICING_HEADER, "sluiceSluicingLimit", 300, "How many times a sluice can be used in a chunk before it becomes overworked. (Default 300)");
 
 		TFCOptions.simSpeedNoPlayers = TFCOptions.getIntFor(config, SERVER_HEADER, "simSpeedNoPlayers", 100, "For every X number of ticks provided here, when there are no players online the server will only progress by 1 tick. (Default: 100) Time advances 100 times slower than normal. Setting this to less than 1 will turn this feature off.");
 

--- a/src/Common/com/bioxx/tfc/TileEntities/TESluice.java
+++ b/src/Common/com/bioxx/tfc/TileEntities/TESluice.java
@@ -28,6 +28,7 @@ import com.bioxx.tfc.Core.TFC_Core;
 import com.bioxx.tfc.Core.TFC_Time;
 import com.bioxx.tfc.api.TFCBlocks;
 import com.bioxx.tfc.api.TFCItems;
+import com.bioxx.tfc.api.TFCOptions;
 
 public class TESluice extends TileEntity implements IInventory
 {
@@ -290,7 +291,7 @@ public class TESluice extends TileEntity implements IInventory
 				}
 
 				ChunkData cd = TFC_Core.getCDM(worldObj).getData(xCoord >> 4, zCoord >> 4);
-				if (cd.sluicedAmount > 300)
+				if (cd.sluicedAmount > TFCOptions.sluiceSluicingLimit && TFCOptions.enableSluiceOverworking)
 				{
 					processTimeRemaining = 0;
 					soilAmount = -1;


### PR DESCRIPTION
This adds config options for sluice overworking:
B:enableSluiceOverworking=true
I:goldPanSluicingLimit=50
I:sluiceSluicingLimit=300

Negative numbers are not a problem and non-numericals are already handled with the proper error messages.