### PR TITLE
Reworked quern processing for food so it handles weight in recipe.

### DIFF
--- a/src/API/com/bioxx/tfc/api/Food.java
+++ b/src/API/com/bioxx/tfc/api/Food.java
@@ -12,6 +12,8 @@ import com.bioxx.tfc.api.Interfaces.IFood;
 
 public class Food 
 {
+	private static final String NBT_FOOD_DECAY = "foodDecay";
+	private static final String NBT_FOOD_WEIGHT = "foodWeight";
 	public static final int DRYHOURS = 4;
 	public static final int SMOKEHOURS = 12;
 
@@ -176,16 +178,20 @@ public class Food
 	public static void setDecay(ItemStack is, float value)
 	{
 		NBTTagCompound nbt = getNBT(is);
-		nbt.setFloat("foodDecay", value);
+		nbt.setFloat(NBT_FOOD_DECAY, value);
 		if(value > getWeight(is))
 			is.stackSize = 0;
+	}
+	
+	public static boolean hasDecay(ItemStack is){
+		return is.hasTagCompound() && is.getTagCompound().hasKey(NBT_FOOD_DECAY);
 	}
 
 	public static float getDecay(ItemStack is)
 	{
 		NBTTagCompound nbt = getNBT(is);
-		if (nbt.hasKey("foodDecay"))
-			return nbt.getFloat("foodDecay");
+		if (nbt.hasKey(NBT_FOOD_DECAY))
+			return nbt.getFloat(NBT_FOOD_DECAY);
 		else
 			return 0;
 	}
@@ -208,16 +214,20 @@ public class Food
 	public static void setWeight(ItemStack is, float value)
 	{
 		NBTTagCompound nbt = getNBT(is);
-		nbt.setFloat("foodWeight", value);
+		nbt.setFloat(NBT_FOOD_WEIGHT, value);
 		if(getDecay(is) > value || value <= 0)
 			is.stackSize = 0;
 	}
 
+	public static boolean hasWeight(ItemStack is){
+		return is.hasTagCompound() && is.getTagCompound().hasKey(NBT_FOOD_WEIGHT);
+	}
+	
 	public static float getWeight(ItemStack is)
 	{
 		NBTTagCompound nbt = getNBT(is);
-		if (nbt.hasKey("foodWeight"))
-			return nbt.getFloat("foodWeight");
+		if (nbt.hasKey(NBT_FOOD_WEIGHT))
+			return nbt.getFloat(NBT_FOOD_WEIGHT);
 		else
 			return 0;
 	}

--- a/src/Common/com/bioxx/tfc/TileEntities/TEQuern.java
+++ b/src/Common/com/bioxx/tfc/TileEntities/TEQuern.java
@@ -118,11 +118,11 @@ public class TEQuern extends NetworkTileEntity implements IInventory
 						float outputWeight = Food.getWeight(storage[1]);
 						float newWeight = outputWeight + resultWeight;
 						if (newWeight > Global.FOOD_MAX_WEIGHT) {
-							Food.setWeight(storage[1], newWeight - Global.FOOD_MAX_WEIGHT);
-							Food.setDecay(storage[1], 0); // Decay goes to tossed stack.
 							ItemStack tossStack = storage[1].copy();
 							Food.setWeight(tossStack, Global.FOOD_MAX_WEIGHT);
 							ejectItem(tossStack);
+							// This reset decay on the output itemStack.
+							ItemFoodTFC.createTag(storage[1],newWeight - Global.FOOD_MAX_WEIGHT);
 						} else {
 							Food.setWeight(storage[1], newWeight);
 						}


### PR DESCRIPTION
This enables recipe that consume part of the food stack instead of always using all the weight. It also enables other ratio of production instead of it always being 1-to-1 conversion (for addon support, if anyone wishes so).
As a side effect, quern processing now also doesn't carry decay over to result, instead reducing result weight when not enough food is available (much like salad/sandwich don't have decay from their ingredients).

At the same time, I'd like to suggest changing the recipe for flour to be only 10oz at a time. Like this, 160oz of grain take 16 turn to fully grind in flour, much like 16 graphite (or any other stack of 16 rocks). Grinding 160oz of grain to 160oz of flour seems too easy to me. This change is not included in the request, but I could easily make it so.
