### PR TITLE
Allow snow layers accumulation on side of normal (solid) blocks;

### DIFF
--- a/src/Common/com/bioxx/tfc/Blocks/Vanilla/BlockCustomSnow.java
+++ b/src/Common/com/bioxx/tfc/Blocks/Vanilla/BlockCustomSnow.java
@@ -88,13 +88,14 @@ public class BlockCustomSnow extends BlockTerra
 	@Override
 	public void onEntityCollidedWithBlock(World world, int x, int y, int z, Entity entity)
 	{
+		// meta  speed
+		//    0  0.98   -  one layer
+		//    7  0.10   -  eight layers = like leaves
+		
 		int meta = world.getBlockMetadata(x, y, z) & 7;
-		if(meta > 0)
-		{
-			double speed = 0.58D + 0.4D * (15 / meta / 15);  // CH: intentional? same as  = (meta == 1) ? 0.98 : 0.58;
-			entity.motionX *= speed;
-			entity.motionZ *= speed;
-		}
+		double speed = 0.98 - 0.125 * meta;
+		entity.motionX *= speed;
+		entity.motionZ *= speed;
 	}
 
 	@Override
@@ -199,18 +200,18 @@ public class BlockCustomSnow extends BlockTerra
 		this.blockIcon = registerer.registerIcon(Reference.ModID + ":snow");
 	}
 
-	// CH: this is confusing me: snow accumulates on the top of a step (one block higher than another)
-	// but not on the bottom of the step
 	private boolean canAddSnowCheckNeighbors(World world, int x, int y, int z, int meta)
 	{
-		if (!this.canPlaceBlockAt(world, x, y, z))
-			return true;
-		if (world.getBlock(x, y, z).getMaterial() != Material.snow)
+ 		Block block = world.getBlock(x, y, z);
+ 		
+ 		if (block.getMaterial() == Material.snow)  // if neighbor is snow, allow up to one additional level
+ 			return meta <= (world.getBlockMetadata(x, y, z) & 7);
+		else if (block == TFCBlocks.Leaves || block == TFCBlocks.Leaves2)  // 4 levels if adjacent to leaves (instead of just one level)
+			return meta < 3;  
+		else if (block.isNormalCube())  // if neighbor is a normal block (opaque, render as normal, not power),
+			return meta < 6;            // up to 7 - leave the top layer empty so we just can see the block
+ 		else
 			return false;
-		if (meta > (world.getBlockMetadata(x, y, z) & 7))
-			return false;
-
-		return true;
 	}
 
 	private boolean canAddSnow(World world, int x, int y, int z, int meta)

--- a/src/Common/com/bioxx/tfc/Commands/RemoveSnowCommand.java
+++ b/src/Common/com/bioxx/tfc/Commands/RemoveSnowCommand.java
@@ -1,0 +1,93 @@
+package com.bioxx.tfc.Commands;
+
+import net.minecraft.block.Block;
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.command.WrongUsageException;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.init.Blocks;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.ChatComponentText;
+import net.minecraft.world.WorldServer;
+import net.minecraft.world.chunk.Chunk;
+
+import com.bioxx.tfc.api.TFCBlocks;
+import com.bioxx.tfc.api.TFCOptions;
+
+public class RemoveSnowCommand extends CommandBase
+{
+	private int lastRadius = 0;  // just for confirmation of large radius (lag)
+	
+	@Override
+	public String getCommandName() {
+		return "removesnow";
+	}
+	
+	@Override
+	public String getCommandUsage(ICommandSender icommandsender) {
+		return "removesnow [radius]";
+	}
+
+	@Override
+	public void processCommand(ICommandSender sender, String[] params) {
+		if(!TFCOptions.enableDebugMode)
+			throw new WrongUsageException("sorry, unable to comply, gamemode need to be active");
+		
+		MinecraftServer server = MinecraftServer.getServer();
+		EntityPlayerMP player = getCommandSenderAsPlayer(sender);
+		WorldServer world = server.worldServerForDimension(player.getEntityWorld().provider.dimensionId);
+
+		int count = 0;
+		
+		if(params.length == 0) {
+			player.addChatMessage(new ChatComponentText("Removing Snow"));
+			count += removeSnow(world, (int)player.posX, (int)player.posZ);
+		} else if(params.length == 1) {
+			int radius;
+			try {
+				radius = Integer.parseInt(params[0]);
+			} catch (NumberFormatException ex) {
+				throw new WrongUsageException(ex.getMessage());
+			}
+			if (radius < 0) 
+				throw new WrongUsageException("A negative radius would disrupt the world: " + radius);
+			if (radius > 10 && radius != lastRadius) {
+				lastRadius = radius;
+				throw new WrongUsageException("Really remove snow within a (square) radius of " + radius + "? This may lag the server, repeat to confirm!");
+			} else {
+				lastRadius = radius;
+				player.addChatMessage(new ChatComponentText("Removing snow within a (square) radius of " + radius));
+				for(int i = -radius; i <= radius; i++) {
+					for(int k = -radius; k <= radius; k++) {
+						count += removeSnow(world, (int)player.posX + (i * 16), (int)player.posZ + (k * 16));
+					}
+				}
+			}
+		} else {
+			throw new WrongUsageException("what do you mean with \"%s\"?", params[1]);
+		}
+		player.addChatMessage(new ChatComponentText("removed " + count + " blocks"));
+	}
+
+	private int removeSnow(WorldServer world, int posX, int posZ) {
+		int count = 0;
+		Chunk chunk = world.getChunkFromBlockCoords(posX, posZ);
+		for(int i = 0; i < 16; i++) {
+			int x = i + (chunk.xPosition * 16);
+			for(int k = 0; k < 16; k++) {
+				int z = k + (chunk.zPosition * 16);
+				int top = world.getTopSolidOrLiquidBlock(x, z);
+				if (top < 1)
+					continue;
+				for (int y = top; y < 256 && y < top+40; y += 1) {
+					Block block = chunk.getBlock(i, y, k);
+					if (block == TFCBlocks.Snow) {
+						world.setBlockToAir(x, y, z);
+						count += 1;
+					}
+				}
+			}
+		}
+		return count;
+	}
+}

--- a/src/Common/com/bioxx/tfc/TerraFirmaCraft.java
+++ b/src/Common/com/bioxx/tfc/TerraFirmaCraft.java
@@ -31,6 +31,7 @@ import com.bioxx.tfc.Commands.GiveSkillCommand;
 import com.bioxx.tfc.Commands.PrintImageMapCommand;
 import com.bioxx.tfc.Commands.RemoveAreaCommand;
 import com.bioxx.tfc.Commands.RemoveChunkCommand;
+import com.bioxx.tfc.Commands.RemoveSnowCommand;
 import com.bioxx.tfc.Commands.SetPlayerStatsCommand;
 import com.bioxx.tfc.Commands.StripChunkCommand;
 import com.bioxx.tfc.Core.ItemHeat;
@@ -337,6 +338,7 @@ public class TerraFirmaCraft
 		evt.registerServerCommand(new PrintImageMapCommand());
 		evt.registerServerCommand(new GiveSkillCommand());
 		evt.registerServerCommand(new CommandTransferTamed());
+		evt.registerServerCommand(new RemoveSnowCommand());
 	}	
 
 	@SubscribeEvent


### PR DESCRIPTION
Changed speed reduction to be linear according snow height and not just one step (integer math);
Added /removesnow command to help testing - removes the top snow blocks from the actual chunk or from a square around the actual one when given a 'radius'

Snow didn't accumulate over 1 layer when having a neighbor block not made of snow, e.g. a dirt block.
On the other side it accumulates on 'steps', that is if the neighbor and the block one below were air.
Old code (snow accumulates on top of the stone block, but not on the bottom next to it):
![Snow Old](https://cloud.githubusercontent.com/assets/2377128/9134852/c18b642e-3cf7-11e5-9084-d35c1b950b45.png)

With this commit, snow would accumulate near normal (solid) blocks, up to 7 layers- one layer intentionally left empty so we can still see the block (just my proposition, makes walking easier).
Example of new code with LOTS of snow:
![Snow New](https://cloud.githubusercontent.com/assets/2377128/9134934/70a0a988-3cf8-11e5-818f-94b98a43028c.png)
