### PR TITLE
SaltWater (or FreshWater or HotWater) is not a NotWater!

### DIFF
--- a/src/Common/com/bioxx/tfc/Core/TFC_Core.java
+++ b/src/Common/com/bioxx/tfc/Core/TFC_Core.java
@@ -471,13 +471,13 @@ public class TFC_Core
 	public static boolean isNotWater(Block block)
 	{
 		return !isSaltWater(block)
-				|| !isFreshWater(block)
-				|| !isHotWater(block);
+				&& !isFreshWater(block)
+				&& !isHotWater(block);
 	}
 
 	public static boolean isHotWater(Block block)
 	{
-		return block == TFCBlocks.HotWater;
+		return block == TFCBlocks.HotWater || block == TFCBlocks.HotWaterStationary;
 	}
 
 	public static boolean isWater(Block block)


### PR DESCRIPTION
isNotWater() should return false if the block is SaltWater or FreshWater or HotWater,
that is, true if it is not SaltWater AND not FreshWater AND not HotWater
(AND instead of OR)
It was always returning true since any block is not SaltWater or not FreshWater at the same time...
but minimal (no) impact since not (yet) being used.