### PR TITLE
Fixed crop growing time on other year length than 96 days.

### DIFF
--- a/src/Common/com/bioxx/tfc/TileEntities/TECrop.java
+++ b/src/Common/com/bioxx/tfc/TileEntities/TECrop.java
@@ -48,7 +48,6 @@ public class TECrop extends NetworkTileEntity
 		Random R = new Random();
 		if(!worldObj.isRemote)
 		{
-			float timeMultiplier = 360 / TFC_Time.daysInYear;
 			CropIndex crop = CropManager.getInstance().getCropFromId(cropId);
 			long time = TFC_Time.getTotalTicks();
 			ChunkData cd = TFC_Core.getCDM(worldObj).getData(xCoord >> 4, zCoord >> 4);
@@ -155,7 +154,7 @@ public class TECrop extends NetworkTileEntity
 						tef.DrainNutrients(3, crop.nutrientUsageMult);
 				}
 
-				float growthRate = ((((crop.numGrowthStages / (crop.growthTime * TFC_Time.timeRatio96)) + tempAdded) * nutriMult) * timeMultiplier) * TFCOptions.cropGrowthMultiplier;
+				float growthRate = ((((crop.numGrowthStages / (crop.growthTime + TFC_Time.timeRatio96)) + tempAdded) * nutriMult) * 3) * TFCOptions.cropGrowthMultiplier;
 				if(tef!= null && tef.isInfested)
 					growthRate /= 2;
 				int oldGrowth = (int) Math.floor(growth);

--- a/src/Common/com/bioxx/tfc/TileEntities/TEFarmland.java
+++ b/src/Common/com/bioxx/tfc/TileEntities/TEFarmland.java
@@ -141,14 +141,14 @@ public class TEFarmland extends NetworkTileEntity
 
 	public int getSoilMax()
 	{
-		float timeMultiplier = TFC_Time.daysInYear / 360f;
-		return (int) (25000 * timeMultiplier);
+//		float timeMultiplier = TFC_Time.daysInYear / 360f;
+//		return (int) (25000 * timeMultiplier);
+	    return 6666;
 	}
 
 	public void DrainNutrients(int type, float multiplier)
 	{
-		float timeMultiplier = 360f / TFC_Time.daysInYear;
-		nutrients[type] -= (100 * multiplier) * timeMultiplier;
+		nutrients[type] -= (100 * multiplier) / TFC_Time.timeRatio360;
 
 		if (nutrients[type] < 0)
 			nutrients[type] = 0;


### PR DESCRIPTION
I've fixed the growth rate formula:
The formula was using both TFC_Time.timeRatio96 and a timeMultiplier (360/TFC_Time.yearLength), so a longer year was way too slow. For example, a year length of 192 should be taking twice as much days, but instead was taking four time as much. So I removed the timeMultiplier and replaced it with the value used in 96 year length: 3, since it was doing an integer division.
The other solution would be to fix timeMultiplier to a float division instead, remove the usage of TFC_Time.timeRatio96 and extends the growthTime of all CropIndex by 1.25 to counter the fix to timeMultiplier (3.75 instead of 3 on a 96 year length).

Also fixed nutrient draining:
Both SoilMax method and DrainNutrient was using a timeMultiplier based on a 360 year length. SoilMax was getting bigger with longer year, and DrainNutrient was getting slower with longer year. This made nutrient draining extremely slow on longer year and thus making crop growth slightly faster than it should be

Growing time on a 96 year length (default) remains unchanged with this fix and growth time properly scale with other year lenght: on a 192 year length, crops take twice as much time. For example, wheat  take roughly 18 days on 96 and 36 ont 192.

Also, you can use the following gist to test crop growth: https://gist.github.com/pgelinas/7a6ac0c79d85554878a7