### PR TITLE
Stopped the despawning of fuel on top of a firepit.

### DIFF
--- a/src/Common/com/bioxx/tfc/Handlers/ItemEventsHandler.java
+++ b/src/Common/com/bioxx/tfc/Handlers/ItemEventsHandler.java
@@ -1,0 +1,36 @@
+package com.bioxx.tfc.Handlers;
+
+import net.minecraft.entity.item.EntityItem;
+import net.minecraft.item.Item;
+import net.minecraft.util.MathHelper;
+import net.minecraft.world.World;
+import net.minecraftforge.event.entity.item.ItemExpireEvent;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+
+import com.bioxx.tfc.TileEntities.TEFirepit;
+import com.bioxx.tfc.api.TFCBlocks;
+import com.bioxx.tfc.api.TFCItems;
+
+/**
+ * @author Dries007
+ */
+public class ItemEventsHandler
+{
+	@SubscribeEvent
+	public void onItemExpire(ItemExpireEvent event)
+	{
+		EntityItem entity = event.entityItem;
+		World world = entity.worldObj;
+		if (!world.isRemote)
+		{
+			Item item = entity.getEntityItem().getItem();
+			if (item == TFCItems.Logs || item == Item.getItemFromBlock(TFCBlocks.Peat))
+			{
+				if (world.getTileEntity(MathHelper.floor_double(entity.posX), MathHelper.floor_double(entity.posY), MathHelper.floor_double(entity.posZ)) instanceof TEFirepit)
+				{
+					event.setCanceled(true); // Adds the normal lifetime of the itemstack back
+				}
+			}
+		}
+	}
+}

--- a/src/Common/com/bioxx/tfc/TerraFirmaCraft.java
+++ b/src/Common/com/bioxx/tfc/TerraFirmaCraft.java
@@ -271,6 +271,9 @@ public class TerraFirmaCraft
 		// Register the Entity Living Update Handler
 		MinecraftForge.EVENT_BUS.register(new EntityLivingHandler());
 
+		// Fully qualified name, so it doesn't conflict with other branches's import changes.
+		MinecraftForge.EVENT_BUS.register(new com.bioxx.tfc.Handlers.ItemEventsHandler());
+
 		// Register all the render stuff for the client
 		proxy.registerRenderInformation();
 


### PR DESCRIPTION
A little change that prevents stacks of fuel from despawning when on top of a firepit.
I'm using the fully qualified name when registering the event handler to prevent merge conflicts with PR #788 