### PR TITLE
HotWaterStationary is HotWater, and HotWater is Water too!

### DIFF
--- a/src/Common/com/bioxx/tfc/Core/TFC_Core.java
+++ b/src/Common/com/bioxx/tfc/Core/TFC_Core.java
@@ -468,22 +468,16 @@ public class TFC_Core
 		return block == TFCBlocks.Peat;
 	}
 
-	public static boolean isNotWater(Block block)
-	{
-		return !isSaltWater(block)
-				|| !isFreshWater(block)
-				|| !isHotWater(block);
-	}
-
 	public static boolean isHotWater(Block block)
 	{
-		return block == TFCBlocks.HotWater;
+		return block == TFCBlocks.HotWater || block == TFCBlocks.HotWaterStationary;
 	}
 
 	public static boolean isWater(Block block)
 	{
 		return isSaltWater(block)
-				|| isFreshWater(block);
+				|| isFreshWater(block)
+				|| isHotWater(block);
 	}
 
 	public static boolean isWaterFlowing(Block block)


### PR DESCRIPTION
isNotWater() should return false if the block is SaltWater or FreshWater or HotWater,
that is, true if it is not SaltWater AND not FreshWater AND not HotWater
(AND instead of OR)
It was always returning true since any block is not SaltWater OR not FreshWater at the same time...
but minimal (no) impact since not (yet) being used.
isNotWater() removed - use !isWater()!

HotWaterStationary blocks should also be considered HotWater;
HotWater should be considered Water.