### PR TITLE
Client can only enter DebugMode if server is in debugmode.

### DIFF
--- a/src/Common/com/bioxx/tfc/Handlers/Network/InitClientWorldPacket.java
+++ b/src/Common/com/bioxx/tfc/Handlers/Network/InitClientWorldPacket.java
@@ -35,6 +35,7 @@ public class InitClientWorldPacket extends AbstractPacket
 	private int daysInYear, HGRate, HGCap;
 	private HashMap<String, Integer> skillMap = new HashMap<String, Integer>();
 	private byte chiselMode;
+	private boolean debugMode = false;
 
 	public InitClientWorldPacket() {}
 
@@ -63,6 +64,7 @@ public class InitClientWorldPacket extends AbstractPacket
 			this.craftingTable = true;
 		this.playerSkills = TFC_Core.getSkillStats(P);
 		this.chiselMode = PlayerManagerTFC.getInstance().getPlayerInfoFromPlayer(P).ChiselMode;
+		this.debugMode = TFCOptions.enableDebugMode;
 	}
 
 	@Override
@@ -130,7 +132,6 @@ public class InitClientWorldPacket extends AbstractPacket
 		fs.nutrProtein = this.nutrProtein;
 		fs.nutrDairy = this.nutrDairy;
 		TFC_Core.setPlayerFoodStats(player, fs);
-
 		TFC_Time.setYearLength(this.daysInYear);
 		TFCOptions.HealthGainRate = this.HGRate;
 		TFCOptions.HealthGainCap = this.HGCap;
@@ -154,7 +155,7 @@ public class InitClientWorldPacket extends AbstractPacket
 				player.getUniqueID()));
 
 		PlayerManagerTFC.getInstance().getClientPlayer().setChiselMode(this.chiselMode);
-
+		TFCOptions.enableDebugMode = this.debugMode && TFCOptions.enableDebugMode;
 
 	}
 

--- a/src/Common/com/bioxx/tfc/Handlers/Network/PlayerUpdatePacket.java
+++ b/src/Common/com/bioxx/tfc/Handlers/Network/PlayerUpdatePacket.java
@@ -1,5 +1,6 @@
 package com.bioxx.tfc.Handlers.Network;
 
+
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 
@@ -13,6 +14,7 @@ import com.bioxx.tfc.Core.TFC_Core;
 import com.bioxx.tfc.Core.Player.FoodStatsTFC;
 import com.bioxx.tfc.Core.Player.PlayerInventory;
 import com.bioxx.tfc.Core.Player.SkillStats;
+import com.bioxx.tfc.api.TFCOptions;
 
 import cpw.mods.fml.common.network.ByteBufUtils;
 
@@ -32,6 +34,7 @@ public class PlayerUpdatePacket extends AbstractPacket
 	private int skillLevel;
 	private boolean craftingTable = false;
 	private HashMap<String, Integer> skillMap = new HashMap<String, Integer>();
+	private boolean debugMode = false;
 
 	public PlayerUpdatePacket() {}
 
@@ -49,6 +52,7 @@ public class PlayerUpdatePacket extends AbstractPacket
 			this.nutrGrain = fs.nutrGrain;
 			this.nutrProtein = fs.nutrProtein;
 			this.nutrDairy = fs.nutrDairy;
+			this.debugMode = TFCOptions.enableDebugMode;
 		}
 		else if(this.flag == 2)
 		{
@@ -88,6 +92,7 @@ public class PlayerUpdatePacket extends AbstractPacket
 			buffer.writeFloat(this.nutrGrain);
 			buffer.writeFloat(this.nutrProtein);
 			buffer.writeFloat(this.nutrDairy);
+			buffer.writeBoolean(this.debugMode);
 		}
 		else if(this.flag == 1)
 		{
@@ -122,6 +127,7 @@ public class PlayerUpdatePacket extends AbstractPacket
 			this.nutrGrain = buffer.readFloat();
 			this.nutrProtein = buffer.readFloat();
 			this.nutrDairy = buffer.readFloat();
+			this.debugMode = buffer.readBoolean();
 		}
 		else if(this.flag == 1)
 		{
@@ -165,6 +171,7 @@ public class PlayerUpdatePacket extends AbstractPacket
 			fs.nutrGrain = this.nutrGrain;
 			fs.nutrProtein = this.nutrProtein;
 			fs.nutrDairy = this.nutrDairy;
+			TFCOptions.enableDebugMode = this.debugMode && TFCOptions.enableDebugMode;
 			TFC_Core.setPlayerFoodStats(player, fs);
 		}
 		else if(this.flag == 1)


### PR DESCRIPTION
Saw your commit Kitty just as I was about to submit this one. However, your commit still allows the client to enter the debugmode command again. The reason we would like this change is to prevent users from accessing the 'cheaty' info available from the debug overlay.

So this commit, instead of a separate packet, adds a boolean to the clientupdate packet and thus is sent both on InitClientWorld and PlayerUpdatePacket.

It ANDS the status together so that if the server is in debug mode, the client isn't forced into debug mode. The debugmode overlay would only display when both the server and the client are in debug mode.