### PR TITLE
Fixed the CaseInsensitiveHashMap compile errors on older Java versions

### DIFF
--- a/src/Common/com/bioxx/tfc/Core/Util/CaseInsensitiveHashMap.java
+++ b/src/Common/com/bioxx/tfc/Core/Util/CaseInsensitiveHashMap.java
@@ -40,7 +40,10 @@ public class CaseInsensitiveHashMap<V> extends HashMap<String, V>
 	private static Map<String, Object> toLowercase(Map<? extends String, ?> m)
 	{
 		ImmutableMap.Builder<String, Object> temp = ImmutableMap.builder();
-		for (Entry<? extends String, ?> entry : m.entrySet())
+		// Must use Map.Entry here, not (Hashmap.)Entry, as the latter is a private inner class on some JDK's.
+		// (Hashmap.)Entry has been replaced by (Hashmap.)Node in Oracle's JDK, wich is why it likely won't error in a dev env.
+		// Thanks Stackoverflow & Grepcode
+		for (Map.Entry<? extends String, ?> entry : m.entrySet())
 		{
 			temp.put(toLowercase(entry.getKey()), entry.getValue());
 		}


### PR DESCRIPTION
A little explanation: The map interface has a (public) inner interface called Entry, used by the .entrySet() method.
In older JDK's the HashMap class defines a (package local) inner class called Entry, which, when you make a class that extends HashMap, can cause naming conflicts when you don't use Map.Entry. [Example: OpenJDK 6 and 7](http://grepcode.com/file/repository.grepcode.com/java/root/jdk/openjdk/6-b14/java/util/HashMap.java#HashMap.Entry)
Java 8 JDK's don't have this issue as they use an inner class called Node. [Example: OpenJDK 8](http://grepcode.com/file/repository.grepcode.com/java/root/jdk/openjdk/8-b132/java/util/HashMap.java#HashMap.Node)

Unfortunately, these types of issues can't be easily detected without actually using an (outdated) Java 7 JDK, as setting the targetCompatibility & sourceCompatibility options in gradle and the project language setting in IntelliJ didn't catch it.