### PR TITLE
Added enableBowlsAlwaysBreak option + fixed logic of ConfigSyncPacket

### DIFF
--- a/src/API/com/bioxx/tfc/api/Crafting/CraftingManagerTFC.java
+++ b/src/API/com/bioxx/tfc/api/Crafting/CraftingManagerTFC.java
@@ -30,7 +30,7 @@ public class CraftingManagerTFC
 		//System.out.println(new StringBuilder().append(recipes.size()).append(" recipes").toString());
 	}
 
-	public void addRecipe(ItemStack itemstack, Object aobj[])
+	public ShapedRecipesTFC addRecipe(ItemStack itemstack, Object aobj[])
 	{
 		String s = "";
 		int i = 0;
@@ -91,10 +91,12 @@ public class CraftingManagerTFC
 			}
 		}
 
-		recipes.add(new ShapedRecipesTFC(j, k, aitemstack, itemstack));
+		ShapedRecipesTFC shapedRecipesTFC = new ShapedRecipesTFC(j, k, aitemstack, itemstack);
+		recipes.add(shapedRecipesTFC);
+		return shapedRecipesTFC;
 	}
 
-	public void addShapelessRecipe(ItemStack itemstack, Object aobj[])
+	public ShapelessRecipesTFC addShapelessRecipe(ItemStack itemstack, Object aobj[])
 	{
 		ArrayList<ItemStack> arraylist = new ArrayList<ItemStack>();
 		Object aobj1[] = aobj;
@@ -121,8 +123,9 @@ public class CraftingManagerTFC
 				throw new RuntimeException("Invalid shapeless recipy!");
 			}
 		}
-
-		recipes.add(new ShapelessRecipesTFC(itemstack, arraylist));
+		ShapelessRecipesTFC recipesTFC = new ShapelessRecipesTFC(itemstack, arraylist);
+		recipes.add(recipesTFC);
+		return recipesTFC;
 	}
 
 	public ItemStack findMatchingRecipe(InventoryCrafting inventorycrafting, World world)

--- a/src/API/com/bioxx/tfc/api/TFCCrafting.java
+++ b/src/API/com/bioxx/tfc/api/TFCCrafting.java
@@ -81,4 +81,6 @@ public class TFCCrafting
 	public static boolean woodStairsRecipe;
 	public static boolean woodToolsRecipe;
 	public static boolean woolRecipe;
+
+	public static boolean enableBowlsAlwaysBreak;
 }

--- a/src/Common/com/bioxx/tfc/Core/Config/ConversionOption.java
+++ b/src/Common/com/bioxx/tfc/Core/Config/ConversionOption.java
@@ -7,8 +7,8 @@ import com.google.common.collect.ImmutableList;
 
 /**
  * Used to represent the "conversion" option
- * When the value (config or from server, depending on context) is true the recipes are (re)added to the recipe list.
- * Also keeps the static values from the TFCCrafting class in sync with the actual status of things.
+ * Since normally the recipes affected by this class are new recipes, they don't have to be removed in the constructor.
+ * If this is not the case, you must remove them after initializing the object, but before the loadFromConfig is called. Otherwise you may end up with double entries in the recipe list.
  * @author Dries007
  */
 public class ConversionOption extends SyncingOption

--- a/src/Common/com/bioxx/tfc/Core/Config/SyncingOption.java
+++ b/src/Common/com/bioxx/tfc/Core/Config/SyncingOption.java
@@ -14,6 +14,9 @@ import com.google.common.collect.ImmutableList;
 import static com.bioxx.tfc.Core.Config.TFC_ConfigFiles.SYNCING_OPTION_MAP;
 
 /**
+ * When the value (config or from server, depending on context) is true the recipes are (re)added to the recipe list. Otherwise they are removed.
+ * This behaviour may be changed by overriding the .apply(boolean) method
+ * Also keeps the static values from the class passed in the constructor in sync with the actual status of things.
  * @author Dries007
  */
 public abstract class SyncingOption
@@ -24,8 +27,8 @@ public abstract class SyncingOption
 	public final Configuration cfg;
 	public final String cat;
 
-	private boolean ourConfigValue;
-	private boolean currentValue;
+	protected boolean ourConfigValue;
+	protected boolean currentValue;
 
 	public SyncingOption(String name, Class<?> clazz, Configuration cfg, String cat) throws NoSuchFieldException, IllegalAccessException
 	{

--- a/src/Common/com/bioxx/tfc/Core/Config/TFC_ConfigFiles.java
+++ b/src/Common/com/bioxx/tfc/Core/Config/TFC_ConfigFiles.java
@@ -287,8 +287,6 @@ public class TFC_ConfigFiles
 				@Override
 				public void apply(boolean enabled) throws IllegalAccessException
 				{
-					TerraFirmaCraft.LOG.info("TEST name {} default {} outCfg {} current {} enabled {}", name, defaultValue, ourConfigValue, currentValue, enabled);
-
 					if (currentValue != enabled) // if we need to change states
 					{
 						recipesTFC.getRecipeOutput().stackSize = enabled ? 4 : 2;
@@ -296,8 +294,6 @@ public class TFC_ConfigFiles
 						field.setBoolean(null, enabled); // Keep the field up to date as well
 						currentValue = enabled;
 					}
-
-					TerraFirmaCraft.LOG.info("enableBowlsAlwaysBreak option {} changed from {} to {}. Stacksize {}", name, currentValue, enabled, recipesTFC.getRecipeOutput().stackSize);
 				}
 
 				@Override

--- a/src/Common/com/bioxx/tfc/Core/Config/VanillaRecipeOption.java
+++ b/src/Common/com/bioxx/tfc/Core/Config/VanillaRecipeOption.java
@@ -9,8 +9,7 @@ import com.google.common.collect.ImmutableList;
 
 /**
  * Used to represent the "enable vanilla recipe" option
- * When the value (config or from server, depending on context) is true the recipes are (re)added to the recipe list.
- * Also keeps the static values from the TFCCrafting class in sync with the actual status of things.
+ * This removes the recipes affected in the constructor, to be re-added later if required.
  * @author Dries007
  */
 public class VanillaRecipeOption extends SyncingOption

--- a/src/Common/com/bioxx/tfc/Core/Recipes.java
+++ b/src/Common/com/bioxx/tfc/Core/Recipes.java
@@ -887,6 +887,7 @@ public class Recipes
 			" ### ",
 			" ### ",
 			"     ", '#', new ItemStack(TFCItems.flatClay, 1, 1)});
+		/* Moved to TFC_ConfigFiles.firstLoadCrafting(), as it is dependant on a configureation option.
 		CraftingManagerTFC.getInstance().addRecipe(new ItemStack(TFCItems.potteryBowl, 2), new Object[]
 		{
 			"#####",
@@ -894,6 +895,7 @@ public class Recipes
 			"#####",
 			" ### ",
 			"#   #", '#', new ItemStack(TFCItems.flatClay, 1, 1)});
+		*/
 	}
 
 	private static void registerAlloys()

--- a/src/Common/com/bioxx/tfc/Food/ItemSalad.java
+++ b/src/Common/com/bioxx/tfc/Food/ItemSalad.java
@@ -12,6 +12,7 @@ import net.minecraft.world.World;
 
 import com.bioxx.tfc.Core.TFC_Sounds;
 import com.bioxx.tfc.Core.TFC_Time;
+import com.bioxx.tfc.api.TFCCrafting;
 import com.bioxx.tfc.api.TFCItems;
 
 public class ItemSalad extends ItemMeal
@@ -58,8 +59,8 @@ public class ItemSalad extends ItemMeal
 		// If the last of the salad has been eaten
 		if (is.stackSize == 0)
 		{
-			// 50% chance the bowl is broken, and the sound is played
-			if (world.rand.nextInt(2) == 0)
+			// Blows always break OR 50% chance the bowl is broken, and the sound is played
+			if (TFCCrafting.enableBowlsAlwaysBreak || world.rand.nextInt(2) == 0)
 			{
 				world.playSoundAtEntity(player, TFC_Sounds.CERAMICBREAK, 0.7f, player.worldObj.rand.nextFloat() * 0.2F + 0.8F);
 			}

--- a/src/Common/com/bioxx/tfc/Handlers/Network/ConfigSyncPacket.java
+++ b/src/Common/com/bioxx/tfc/Handlers/Network/ConfigSyncPacket.java
@@ -34,7 +34,7 @@ public class ConfigSyncPacket extends AbstractPacket
 		for (SyncingOption option : SYNCING_OPTION_MAP.values())
 		{
 			ByteBufUtils.writeUTF8String(buffer, option.name);
-			buffer.writeBoolean(option.isAplied());
+			buffer.writeBoolean(option.inConfig());
 		}
 	}
 

--- a/src/Resources/assets/terrafirmacraft/lang/en_US.lang
+++ b/src/Resources/assets/terrafirmacraft/lang/en_US.lang
@@ -82,6 +82,8 @@ config.gui.TFCCrafting.conversion.tooltip=WARNING: Conversions for food are irre
 
 config.gui.TFCCrafting.vanilla=Vanilla Crafting Recipes
 
+config.gui.TFCCrafting.options=Crafting Options
+
 #==============
 #= Entities = 
 #==============


### PR DESCRIPTION
Made CraftingManagerTFC add(Shapeless)Recipe methods return the recipe that they added.

Added enableBowlsAlwaysBreak in new category in the TFCCrafting.cfg file
This option changes the clay bowl stacksize to 4 if the option is enabled, or 2 is disabled.
It also makes bowls break 100% of the time, ofcourse :smile: 

This also fixes the SSP server not reverting back properly (I don't know how I didn't notice this when testing the first time)

