### PR TITLE
Ore Dictionary Additions and Edits

### DIFF
--- a/src/Common/com/bioxx/tfc/Core/Recipes.java
+++ b/src/Common/com/bioxx/tfc/Core/Recipes.java
@@ -38,8 +38,16 @@ public class Recipes
 	public static Item[] knives;
 	public static Item[] meltedMetal;
 	public static Item[] hammers;
+	public static Item[] picks;
+	public static Item[] proPicks;
+	public static Item[] shovels;
+	public static Item[] hoes;
+	public static Item[] swords;
+	public static Item[] maces;
+	public static Item[] javelins;
 	public static Item[] spindle;
 	public static Item[] gems;
+	public static Item[] seeds;
 	public static Item[] doors;
 
 	public static final int WILD = OreDictionary.WILDCARD_VALUE;

--- a/src/Common/com/bioxx/tfc/Core/TFC_OreDictionary.java
+++ b/src/Common/com/bioxx/tfc/Core/TFC_OreDictionary.java
@@ -40,6 +40,10 @@ public class TFC_OreDictionary
 		OreDictionary.registerOre("treeLeaves", new ItemStack(TFCBlocks.leaves, 1, WILD));
 		OreDictionary.registerOre("treeLeaves", new ItemStack(TFCBlocks.leaves2, 1, WILD));
 
+		//Wood Crafts
+		OreDictionary.registerOre("chestWood", new ItemStack(TFCBlocks.chest, 1, WILD));
+		OreDictionary.registerOre("barrelWood", new ItemStack(TFCBlocks.barrel, 1, WILD));
+
 		//Ores
 		OreDictionary.registerOre("oreNormalCopper", new ItemStack(TFCItems.oreChunk, 1, 0)); //Native Copper
 		OreDictionary.registerOre("oreNormalCopper", new ItemStack(TFCItems.oreChunk, 1, 9)); //Malachite
@@ -166,6 +170,10 @@ public class TFC_OreDictionary
 		OreDictionary.registerOre("ingotBlueSteel", new ItemStack(TFCItems.blueSteelIngot));
 		OreDictionary.registerOre("ingotUnknown", new ItemStack(TFCItems.unknownIngot));
 
+		OreDictionary.registerOre("ingotAnyBronze", new ItemStack(TFCItems.bronzeIngot));
+		OreDictionary.registerOre("ingotAnyBronze", new ItemStack(TFCItems.bismuthBronzeIngot));
+		OreDictionary.registerOre("ingotAnyBronze", new ItemStack(TFCItems.blackBronzeIngot));
+
 		//Double Ingots
 		OreDictionary.registerOre("ingotDoubleBismuth", new ItemStack(TFCItems.bismuthIngot2x));
 		OreDictionary.registerOre("ingotDoubleTin", new ItemStack(TFCItems.tinIngot2x));
@@ -189,6 +197,10 @@ public class TFC_OreDictionary
 		OreDictionary.registerOre("ingotDoubleRedSteel", new ItemStack(TFCItems.redSteelIngot2x));
 		OreDictionary.registerOre("ingotDoubleBlueSteel", new ItemStack(TFCItems.blueSteelIngot2x));
 
+		OreDictionary.registerOre("ingotDoubleAnyBronze", new ItemStack(TFCItems.bronzeIngot2x));
+		OreDictionary.registerOre("ingotDoubleAnyBronze", new ItemStack(TFCItems.bismuthBronzeIngot2x));
+		OreDictionary.registerOre("ingotDoubleAnyBronze", new ItemStack(TFCItems.blackBronzeIngot2x));
+
 		//Sheets
 		OreDictionary.registerOre("plateBismuth", new ItemStack(TFCItems.bismuthSheet));
 		OreDictionary.registerOre("plateTin", new ItemStack(TFCItems.tinSheet));
@@ -205,12 +217,17 @@ public class TFC_OreDictionary
 		OreDictionary.registerOre("plateSterlingSilver", new ItemStack(TFCItems.sterlingSilverSheet));
 		OreDictionary.registerOre("platePlatinum", new ItemStack(TFCItems.platinumSheet));
 		OreDictionary.registerOre("plateWroughtIron", new ItemStack(TFCItems.wroughtIronSheet));
+		OreDictionary.registerOre("plateIron", new ItemStack(TFCItems.wroughtIronSheet));
 		OreDictionary.registerOre("plateNickel", new ItemStack(TFCItems.nickelSheet));
 		OreDictionary.registerOre("platePigIron", new ItemStack(TFCItems.pigIronSheet));
 		OreDictionary.registerOre("plateSteel", new ItemStack(TFCItems.steelSheet));
 		OreDictionary.registerOre("plateBlackSteel", new ItemStack(TFCItems.blackSteelSheet));
 		OreDictionary.registerOre("plateRedSteel", new ItemStack(TFCItems.redSteelSheet));
 		OreDictionary.registerOre("plateBlueSteel", new ItemStack(TFCItems.blueSteelSheet));
+
+		OreDictionary.registerOre("plateAnyBronze", new ItemStack(TFCItems.bronzeSheet));
+		OreDictionary.registerOre("plateAnyBronze", new ItemStack(TFCItems.bismuthBronzeSheet));
+		OreDictionary.registerOre("plateAnyBronze", new ItemStack(TFCItems.blackBronzeSheet));
 
 		//Double Sheets
 		OreDictionary.registerOre("plateDoubleBismuth", new ItemStack(TFCItems.bismuthSheet2x));
@@ -397,14 +414,35 @@ public class TFC_OreDictionary
 		OreDictionary.registerOre("materialCloth", new ItemStack(TFCItems.silkCloth));
 		OreDictionary.registerOre("materialWool", new ItemStack(TFCItems.wool, 1, WILD));
 
+		// Stone Toolheads
+		OreDictionary.registerOre("itemAxeStoneHead", new ItemStack(TFCItems.igExStoneAxeHead, 1, WILD));
+		OreDictionary.registerOre("itemAxeStoneHead", new ItemStack(TFCItems.igInStoneAxeHead, 1, WILD));
+		OreDictionary.registerOre("itemAxeStoneHead", new ItemStack(TFCItems.mMStoneAxeHead, 1, WILD));
+		OreDictionary.registerOre("itemAxeStoneHead", new ItemStack(TFCItems.sedStoneAxeHead, 1, WILD));
+
+		OreDictionary.registerOre("itemHoeStoneHead", new ItemStack(TFCItems.igExStoneHoeHead, 1, WILD));
+		OreDictionary.registerOre("itemHoeStoneHead", new ItemStack(TFCItems.igInStoneHoeHead, 1, WILD));
+		OreDictionary.registerOre("itemHoeStoneHead", new ItemStack(TFCItems.mMStoneHoeHead, 1, WILD));
+		OreDictionary.registerOre("itemHoeStoneHead", new ItemStack(TFCItems.sedStoneHoeHead, 1, WILD));
+
+		OreDictionary.registerOre("itemShovelStoneHead", new ItemStack(TFCItems.igExStoneShovelHead, 1, WILD));
+		OreDictionary.registerOre("itemShovelStoneHead", new ItemStack(TFCItems.igInStoneShovelHead, 1, WILD));
+		OreDictionary.registerOre("itemShovelStoneHead", new ItemStack(TFCItems.mMStoneShovelHead, 1, WILD));
+		OreDictionary.registerOre("itemShovelStoneHead", new ItemStack(TFCItems.sedStoneShovelHead, 1, WILD));
+
+		OreDictionary.registerOre("itemJavelinStoneHead", new ItemStack(TFCItems.igExStoneJavelinHead, 1, WILD));
+		OreDictionary.registerOre("itemJavelinStoneHead", new ItemStack(TFCItems.igInStoneJavelinHead, 1, WILD));
+		OreDictionary.registerOre("itemJavelinStoneHead", new ItemStack(TFCItems.mMStoneJavelinHead, 1, WILD));
+		OreDictionary.registerOre("itemJavelinStoneHead", new ItemStack(TFCItems.sedStoneJavelinHead, 1, WILD));
+
 		// Tools are also registered with their material to help prevent issues with unification.
 		for (Item axe : Recipes.axes)
 			OreDictionary.registerOre("itemAxe", new ItemStack(axe, 1, WILD));
 
-		OreDictionary.registerOre("itemAxeStoneSed", new ItemStack(TFCItems.sedAxe, 1, WILD));
-		OreDictionary.registerOre("itemAxeStoneIgIn", new ItemStack(TFCItems.igInAxe, 1, WILD));
-		OreDictionary.registerOre("itemAxeStoneIgEx", new ItemStack(TFCItems.igExAxe, 1, WILD));
-		OreDictionary.registerOre("itemAxeStoneMM", new ItemStack(TFCItems.mMAxe, 1, WILD));
+		OreDictionary.registerOre("itemAxeStone", new ItemStack(TFCItems.sedAxe, 1, WILD));
+		OreDictionary.registerOre("itemAxeStone", new ItemStack(TFCItems.igInAxe, 1, WILD));
+		OreDictionary.registerOre("itemAxeStone", new ItemStack(TFCItems.igExAxe, 1, WILD));
+		OreDictionary.registerOre("itemAxeStone", new ItemStack(TFCItems.mMAxe, 1, WILD));
 		OreDictionary.registerOre("itemAxeBismuthBronze", new ItemStack(TFCItems.bismuthBronzeAxe, 1, WILD));
 		OreDictionary.registerOre("itemAxeBlackBronze", new ItemStack(TFCItems.blackBronzeAxe, 1, WILD));
 		OreDictionary.registerOre("itemAxeBlackSteel", new ItemStack(TFCItems.blackSteelAxe, 1, WILD));
@@ -482,6 +520,110 @@ public class TFC_OreDictionary
 		OreDictionary.registerOre("itemScytheRedSteel", new ItemStack(TFCItems.redSteelScythe, 1, WILD));
 		OreDictionary.registerOre("itemScytheSteel", new ItemStack(TFCItems.steelScythe, 1, WILD));
 
+		for (Item pick : Recipes.picks)
+			OreDictionary.registerOre("itemPick", new ItemStack(pick, 1, WILD));
+
+		OreDictionary.registerOre("itemPickBismuthBronze", new ItemStack(TFCItems.bismuthBronzePick, 1, WILD));
+		OreDictionary.registerOre("itemPickBlackBronze", new ItemStack(TFCItems.blackBronzePick, 1, WILD));
+		OreDictionary.registerOre("itemPickBlackSteel", new ItemStack(TFCItems.blackSteelPick, 1, WILD));
+		OreDictionary.registerOre("itemPickBlueSteel", new ItemStack(TFCItems.blueSteelPick, 1, WILD));
+		OreDictionary.registerOre("itemPickBronze", new ItemStack(TFCItems.bronzePick, 1, WILD));
+		OreDictionary.registerOre("itemPickCopper", new ItemStack(TFCItems.copperPick, 1, WILD));
+		OreDictionary.registerOre("itemPickWroughtIron", new ItemStack(TFCItems.wroughtIronPick, 1, WILD));
+		OreDictionary.registerOre("itemPickRedSteel", new ItemStack(TFCItems.redSteelPick, 1, WILD));
+		OreDictionary.registerOre("itemPickSteel", new ItemStack(TFCItems.steelPick, 1, WILD));
+
+		for (Item proPick : Recipes.proPicks)
+			OreDictionary.registerOre("itemProPick", new ItemStack(proPick, 1, WILD));
+
+		OreDictionary.registerOre("itemProPickBismuthBronze", new ItemStack(TFCItems.proPickBismuthBronze, 1, WILD));
+		OreDictionary.registerOre("itemProPickBlackBronze", new ItemStack(TFCItems.proPickBlackBronze, 1, WILD));
+		OreDictionary.registerOre("itemProPickBlackSteel", new ItemStack(TFCItems.proPickBlackSteel, 1, WILD));
+		OreDictionary.registerOre("itemProPickBlueSteel", new ItemStack(TFCItems.proPickBlueSteel, 1, WILD));
+		OreDictionary.registerOre("itemProPickBronze", new ItemStack(TFCItems.proPickBronze, 1, WILD));
+		OreDictionary.registerOre("itemProPickCopper", new ItemStack(TFCItems.proPickCopper, 1, WILD));
+		OreDictionary.registerOre("itemProPickWroughtIron", new ItemStack(TFCItems.proPickIron, 1, WILD));
+		OreDictionary.registerOre("itemProPickRedSteel", new ItemStack(TFCItems.proPickRedSteel, 1, WILD));
+		OreDictionary.registerOre("itemProPickSteel", new ItemStack(TFCItems.proPickSteel, 1, WILD));
+
+		for (Item shovel : Recipes.shovels)
+			OreDictionary.registerOre("itemShovel", new ItemStack(shovel, 1, WILD));
+
+		OreDictionary.registerOre("itemShovelStone", new ItemStack(TFCItems.sedShovel, 1, WILD));
+		OreDictionary.registerOre("itemShovelStone", new ItemStack(TFCItems.igInShovel, 1, WILD));
+		OreDictionary.registerOre("itemShovelStone", new ItemStack(TFCItems.igExShovel, 1, WILD));
+		OreDictionary.registerOre("itemShovelStone", new ItemStack(TFCItems.mMShovel, 1, WILD));
+		OreDictionary.registerOre("itemShovelBismuthBronze", new ItemStack(TFCItems.bismuthBronzeShovel, 1, WILD));
+		OreDictionary.registerOre("itemShovelBlackBronze", new ItemStack(TFCItems.blackBronzeShovel, 1, WILD));
+		OreDictionary.registerOre("itemShovelBlackSteel", new ItemStack(TFCItems.blackSteelShovel, 1, WILD));
+		OreDictionary.registerOre("itemShovelBlueSteel", new ItemStack(TFCItems.blueSteelShovel, 1, WILD));
+		OreDictionary.registerOre("itemShovelBronze", new ItemStack(TFCItems.bronzeShovel, 1, WILD));
+		OreDictionary.registerOre("itemShovelCopper", new ItemStack(TFCItems.copperShovel, 1, WILD));
+		OreDictionary.registerOre("itemShovelWroughtIron", new ItemStack(TFCItems.wroughtIronShovel, 1, WILD));
+		OreDictionary.registerOre("itemShovelRedSteel", new ItemStack(TFCItems.redSteelShovel, 1, WILD));
+		OreDictionary.registerOre("itemShovelSteel", new ItemStack(TFCItems.steelShovel, 1, WILD));
+
+		for (Item hoe : Recipes.hoes)
+			OreDictionary.registerOre("itemHoe", new ItemStack(hoe, 1, WILD));
+
+		OreDictionary.registerOre("itemHoeStone", new ItemStack(TFCItems.sedHoe, 1, WILD));
+		OreDictionary.registerOre("itemHoeStone", new ItemStack(TFCItems.igInHoe, 1, WILD));
+		OreDictionary.registerOre("itemHoeStone", new ItemStack(TFCItems.igExHoe, 1, WILD));
+		OreDictionary.registerOre("itemHoeStone", new ItemStack(TFCItems.mMHoe, 1, WILD));
+		OreDictionary.registerOre("itemHoeBismuthBronze", new ItemStack(TFCItems.bismuthBronzeHoe, 1, WILD));
+		OreDictionary.registerOre("itemHoeBlackBronze", new ItemStack(TFCItems.blackBronzeHoe, 1, WILD));
+		OreDictionary.registerOre("itemHoeBlackSteel", new ItemStack(TFCItems.blackSteelHoe, 1, WILD));
+		OreDictionary.registerOre("itemHoeBlueSteel", new ItemStack(TFCItems.blueSteelHoe, 1, WILD));
+		OreDictionary.registerOre("itemHoeBronze", new ItemStack(TFCItems.bronzeHoe, 1, WILD));
+		OreDictionary.registerOre("itemHoeCopper", new ItemStack(TFCItems.copperHoe, 1, WILD));
+		OreDictionary.registerOre("itemHoeWroughtIron", new ItemStack(TFCItems.wroughtIronHoe, 1, WILD));
+		OreDictionary.registerOre("itemHoeRedSteel", new ItemStack(TFCItems.redSteelHoe, 1, WILD));
+		OreDictionary.registerOre("itemHoeSteel", new ItemStack(TFCItems.steelHoe, 1, WILD));
+
+		//Weapons are also registered with their material to help prevent issues with unification.
+		for (Item sword : Recipes.swords)
+			OreDictionary.registerOre("itemSword", new ItemStack(sword, 1, WILD));
+
+		OreDictionary.registerOre("itemSwordBismuthBronze", new ItemStack(TFCItems.bismuthBronzeSword, 1, WILD));
+		OreDictionary.registerOre("itemSwordBlackBronze", new ItemStack(TFCItems.blackBronzeSword, 1, WILD));
+		OreDictionary.registerOre("itemSwordBlackSteel", new ItemStack(TFCItems.blackSteelSword, 1, WILD));
+		OreDictionary.registerOre("itemSwordBlueSteel", new ItemStack(TFCItems.blueSteelSword, 1, WILD));
+		OreDictionary.registerOre("itemSwordBronze", new ItemStack(TFCItems.bronzeSword, 1, WILD));
+		OreDictionary.registerOre("itemSwordCopper", new ItemStack(TFCItems.copperSword, 1, WILD));
+		OreDictionary.registerOre("itemSwordWroughtIron", new ItemStack(TFCItems.wroughtIronSword, 1, WILD));
+		OreDictionary.registerOre("itemSwordRedSteel", new ItemStack(TFCItems.redSteelSword, 1, WILD));
+		OreDictionary.registerOre("itemSwordSteel", new ItemStack(TFCItems.steelSword, 1, WILD));
+
+		for (Item mace : Recipes.maces)
+			OreDictionary.registerOre("itemMace", new ItemStack(mace, 1, WILD));
+
+		OreDictionary.registerOre("itemMaceBismuthBronze", new ItemStack(TFCItems.bismuthBronzeMace, 1, WILD));
+		OreDictionary.registerOre("itemMaceBlackBronze", new ItemStack(TFCItems.blackBronzeMace, 1, WILD));
+		OreDictionary.registerOre("itemMaceBlackSteel", new ItemStack(TFCItems.blackSteelMace, 1, WILD));
+		OreDictionary.registerOre("itemMaceBlueSteel", new ItemStack(TFCItems.blueSteelMace, 1, WILD));
+		OreDictionary.registerOre("itemMaceBronze", new ItemStack(TFCItems.bronzeMace, 1, WILD));
+		OreDictionary.registerOre("itemMaceCopper", new ItemStack(TFCItems.copperMace, 1, WILD));
+		OreDictionary.registerOre("itemMaceWroughtIron", new ItemStack(TFCItems.wroughtIronMace, 1, WILD));
+		OreDictionary.registerOre("itemMaceRedSteel", new ItemStack(TFCItems.redSteelMace, 1, WILD));
+		OreDictionary.registerOre("itemMaceSteel", new ItemStack(TFCItems.steelMace, 1, WILD));
+
+		for (Item javelin : Recipes.javelins)
+			OreDictionary.registerOre("itemJavelin", new ItemStack(javelin, 1, WILD));
+
+		OreDictionary.registerOre("itemJavelinStone", new ItemStack(TFCItems.sedStoneJavelin, 1, WILD));
+		OreDictionary.registerOre("itemJavelinStone", new ItemStack(TFCItems.igInStoneJavelin, 1, WILD));
+		OreDictionary.registerOre("itemJavelinStone", new ItemStack(TFCItems.igExStoneJavelin, 1, WILD));
+		OreDictionary.registerOre("itemJavelinStone", new ItemStack(TFCItems.mMStoneJavelin, 1, WILD));
+		OreDictionary.registerOre("itemJavelinBismuthBronze", new ItemStack(TFCItems.bismuthBronzeJavelin, 1, WILD));
+		OreDictionary.registerOre("itemJavelinBlackBronze", new ItemStack(TFCItems.blackBronzeJavelin, 1, WILD));
+		OreDictionary.registerOre("itemJavelinBlackSteel", new ItemStack(TFCItems.blackSteelJavelin, 1, WILD));
+		OreDictionary.registerOre("itemJavelinBlueSteel", new ItemStack(TFCItems.blueSteelJavelin, 1, WILD));
+		OreDictionary.registerOre("itemJavelinBronze", new ItemStack(TFCItems.bronzeJavelin, 1, WILD));
+		OreDictionary.registerOre("itemJavelinCopper", new ItemStack(TFCItems.copperJavelin, 1, WILD));
+		OreDictionary.registerOre("itemJavelinWroughtIron", new ItemStack(TFCItems.wroughtIronJavelin, 1, WILD));
+		OreDictionary.registerOre("itemJavelinRedSteel", new ItemStack(TFCItems.redSteelJavelin, 1, WILD));
+		OreDictionary.registerOre("itemJavelinSteel", new ItemStack(TFCItems.steelJavelin, 1, WILD));
+
 		//Miscellaneous Items
 		OreDictionary.registerOre("lumpClay", new ItemStack(Items.clay_ball));
 		OreDictionary.registerOre("lumpClay", new ItemStack(TFCItems.clayBall, 1, 0));
@@ -517,10 +659,17 @@ public class TFC_OreDictionary
 		OreDictionary.registerOre("bucketMilk", new ItemStack(Items.milk_bucket));
 		OreDictionary.registerOre("bucketMilk", new ItemStack(TFCItems.woodenBucketMilk));
 
+		OreDictionary.registerOre("toolFlintSteel", new ItemStack(Items.flint_and_steel, 1, WILD));
+		OreDictionary.registerOre("toolFlintSteel", new ItemStack(TFCItems.flintSteel, 1, WILD));
+
 		//Miscellaneous Blocks
 		OreDictionary.registerOre("blockSand", new ItemStack(Blocks.sand));
 		OreDictionary.registerOre("blockSand", new ItemStack(TFCBlocks.sand, 1, WILD));
 		OreDictionary.registerOre("blockSand", new ItemStack(TFCBlocks.sand2, 1, WILD));
+
+		OreDictionary.registerOre("blockGravel", new ItemStack(Blocks.gravel));
+		OreDictionary.registerOre("blockGravel", new ItemStack(TFCBlocks.gravel, 1, WILD));
+		OreDictionary.registerOre("blockGravel", new ItemStack(TFCBlocks.gravel2, 1, WILD));
 
 		OreDictionary.registerOre("blockDirt", new ItemStack(Blocks.dirt));
 		OreDictionary.registerOre("blockDirt", new ItemStack(TFCBlocks.dirt, 1, WILD));
@@ -533,5 +682,28 @@ public class TFC_OreDictionary
 		OreDictionary.registerOre("blockPumpkin", new ItemStack(TFCBlocks.pumpkin));
 		OreDictionary.registerOre("blockLitPumpkin", new ItemStack(Blocks.lit_pumpkin));
 		OreDictionary.registerOre("blockLitPumpkin", new ItemStack(TFCBlocks.litPumpkin));
+
+		//Seed Bags
+		for (Item seed : Recipes.seeds)
+			OreDictionary.registerOre("seedBag", new ItemStack(seed, 1, WILD));
+		OreDictionary.registerOre("seedWheat", new ItemStack(TFCItems.seedsWheat, 1, WILD));
+		OreDictionary.registerOre("seedMaize", new ItemStack(TFCItems.seedsMaize, 1, WILD));
+		OreDictionary.registerOre("seedTomato", new ItemStack(TFCItems.seedsTomato, 1, WILD));
+		OreDictionary.registerOre("seedBarley", new ItemStack(TFCItems.seedsBarley, 1, WILD));
+		OreDictionary.registerOre("seedRye", new ItemStack(TFCItems.seedsRye, 1, WILD));
+		OreDictionary.registerOre("seedOat", new ItemStack(TFCItems.seedsOat, 1, WILD));
+		OreDictionary.registerOre("seedRice", new ItemStack(TFCItems.seedsRice, 1, WILD));
+		OreDictionary.registerOre("seedPotato", new ItemStack(TFCItems.seedsPotato, 1, WILD));
+		OreDictionary.registerOre("seedOnion", new ItemStack(TFCItems.seedsOnion, 1, WILD));
+		OreDictionary.registerOre("seedCabbage", new ItemStack(TFCItems.seedsCabbage, 1, WILD));
+		OreDictionary.registerOre("seedGarlic", new ItemStack(TFCItems.seedsGarlic, 1, WILD));
+		OreDictionary.registerOre("seedCarrot", new ItemStack(TFCItems.seedsCarrot, 1, WILD));
+		OreDictionary.registerOre("seedSugarcane", new ItemStack(TFCItems.seedsSugarcane, 1, WILD));
+		OreDictionary.registerOre("seedYelloBellPepper", new ItemStack(TFCItems.seedsYellowBellPepper, 1, WILD));
+		OreDictionary.registerOre("seedRedBellPepper", new ItemStack(TFCItems.seedsRedBellPepper, 1, WILD));
+		OreDictionary.registerOre("seedSoybean", new ItemStack(TFCItems.seedsSoybean, 1, WILD));
+		OreDictionary.registerOre("seedGreenbean", new ItemStack(TFCItems.seedsGreenbean, 1, WILD));
+		OreDictionary.registerOre("seedSquash", new ItemStack(TFCItems.seedsSquash, 1, WILD));
+		OreDictionary.registerOre("seedJute", new ItemStack(TFCItems.seedsJute, 1, WILD));
 	}
 }

--- a/src/Common/com/bioxx/tfc/ItemSetup.java
+++ b/src/Common/com/bioxx/tfc/ItemSetup.java
@@ -683,10 +683,46 @@ public class ItemSetup extends TFCItems {
 				blackSteelScythe,blueSteelScythe,bronzeScythe,copperScythe,
 				wroughtIronScythe,redSteelScythe,steelScythe};
 
+		Recipes.picks = new Item[]{bismuthBronzePick,blackBronzePick,
+				blackSteelPick,blueSteelPick,bronzePick,copperPick,
+				wroughtIronPick,redSteelPick,steelPick};
+
+		Recipes.proPicks = new Item[]{proPickBismuthBronze,proPickBlackBronze,
+				proPickBlackSteel,proPickBlueSteel,proPickBronze,proPickCopper,
+				proPickIron,proPickRedSteel,proPickSteel};
+
+		Recipes.shovels = new Item[]{sedShovel,igInShovel,igExShovel,mMShovel,
+				bismuthBronzeShovel,blackBronzeShovel,
+				blackSteelShovel,blueSteelShovel,bronzeShovel,copperShovel,
+				wroughtIronShovel,redSteelShovel,steelShovel};
+
+		Recipes.hoes = new Item[]{sedHoe,igInHoe,igExHoe,mMHoe,
+				bismuthBronzeHoe,blackBronzeHoe,
+				blackSteelHoe,blueSteelHoe,bronzeHoe,copperHoe,
+				wroughtIronHoe,redSteelHoe,steelHoe};
+
+		Recipes.swords = new Item[]{bismuthBronzeSword,blackBronzeSword,
+				blackSteelSword,blueSteelSword,bronzeSword,copperSword,
+				wroughtIronSword,redSteelSword,steelSword};
+
+		Recipes.maces = new Item[]{bismuthBronzeMace,blackBronzeMace,
+				blackSteelMace,blueSteelMace,bronzeMace,copperMace,
+				wroughtIronMace,redSteelMace,steelMace};
+
+		Recipes.javelins = new Item[]{sedStoneJavelin,igInStoneJavelin,
+				igExStoneJavelin,mMStoneJavelin,bismuthBronzeJavelin,
+				blackBronzeJavelin,blackSteelJavelin,blueSteelJavelin,
+				bronzeJavelin,copperJavelin,wroughtIronJavelin,
+				redSteelJavelin,steelJavelin};
+
 		Recipes.spindle = new Item[]{spindle};
 
 		Recipes.gems  = new Item[]{gemAgate, gemAmethyst, gemBeryl, gemDiamond, gemEmerald, gemGarnet, 
 				gemJade, gemJasper, gemOpal,gemRuby,gemSapphire,gemTopaz,gemTourmaline};
+
+		Recipes.seeds  = new Item[]{seedsBarley,seedsCabbage,seedsCarrot,seedsGarlic,seedsGreenbean,seedsJute,seedsMaize,
+				seedsOat,seedsOnion,seedsPotato,seedsRedBellPepper,seedsRice,seedsRye,seedsSoybean,seedsSquash,
+				seedsSugarcane,seedsTomato,seedsWheat,seedsYellowBellPepper};
 
 		((TFCTabs) TFCTabs.TFC_BUILDING).setTabIconItemStack(new ItemStack(TFCBlocks.stoneSedBrick));
 		((TFCTabs) TFCTabs.TFC_DECORATION).setTabIconItemStack(new ItemStack(TFCBlocks.flora));


### PR DESCRIPTION
Additions and edits provide hooks to use in HQM quests and provide
better compatibility.

- TFC chests added to standard chestWood
- TFC barrels added to barrelWood
- wrought iron sheet added to plateIron
- AnyBronze entry added for ingots, double ingots and sheets.
- Stone Tool heads added for Axe, Hoe, Shovel and Javelin
- Sed/IgIn/IgEx/MM removed from stone tool registration
- Remaining TFC Tools registered in general entry and by material
- TFC Weapons registered in general entry and by material
- TFC and Vanilla Flint and Steel registered
- TFC and Vanilla Gravel registered
- TFC Seed bags registered as seedBag and each individual seed is
registered as seedType e.g. seedWheat