### PR TITLE
Convert TFCTools to use ContainerItem to increment...

### DIFF
--- a/src/Common/com/bioxx/tfc/Handlers/CraftingHandler.java
+++ b/src/Common/com/bioxx/tfc/Handlers/CraftingHandler.java
@@ -49,26 +49,8 @@ public class CraftingHandler
 
 		//int index = 0;
 		if(iinventory != null)
-		{
-			// Tool Damaging
-			if(item == TFCItems.stoneBrick)
+			if (item == TFCItems.wool)
 			{
-				List<ItemStack> chisels = OreDictionary.getOres("itemChisel", false);
-				handleItem(player, iinventory, chisels);
-			}
-			else if(item == TFCItems.singlePlank ||
-					item == Item.getItemFromBlock(TFCBlocks.woodSupportH) || item == Item.getItemFromBlock(TFCBlocks.woodSupportH2) ||
-					item == Item.getItemFromBlock(TFCBlocks.woodSupportV) || item == Item.getItemFromBlock(TFCBlocks.woodSupportV2))
-			{
-				List<ItemStack> axes = OreDictionary.getOres("itemAxe", false);
-				List<ItemStack> saws = OreDictionary.getOres("itemSaw", false);
-				handleItem(player, iinventory, axes);
-				handleItem(player, iinventory, saws);
-			}
-			else if (item == TFCItems.wool)
-			{
-				List<ItemStack> knives = OreDictionary.getOres("itemKnife", false);
-				handleItem(player, iinventory, knives);
 				int size = 0;
 				for (int i = 0; i < iinventory.getSizeInventory(); i++)
 				{
@@ -80,15 +62,6 @@ public class CraftingHandler
 				boolean add = !player.inventory.addItemStackToInventory(new ItemStack(TFCItems.hide, 1, size));
 				if (add)
 					player.entityDropItem(new ItemStack(TFCItems.hide, 1, size), 1);
-			}
-			else if(item == TFCItems.woolYarn)
-			{
-				handleItem(player, iinventory, Recipes.spindle);
-			}
-			else if (item == TFCItems.powder && itemDamage == 0)
-			{
-				List<ItemStack> hammers = OreDictionary.getOres("itemHammer", false);
-				handleItem(player, iinventory, hammers);
 			}
 
 			// Achievements

--- a/src/Common/com/bioxx/tfc/Items/Tools/ItemCustomAxe.java
+++ b/src/Common/com/bioxx/tfc/Items/Tools/ItemCustomAxe.java
@@ -77,6 +77,39 @@ public class ItemCustomAxe extends ItemAxe implements ISize, ICausesDamage
 	}
 
 	@Override
+	public boolean doesContainerItemLeaveCraftingGrid(ItemStack ItemStack)
+	{
+		return false;
+	}
+
+	@Override
+	public boolean getShareTag()
+	{
+		return true;
+	}
+
+	@Override
+	public ItemStack getContainerItem(ItemStack itemStack)
+	{
+		ItemStack container = itemStack.copy();
+		container.setItemDamage(container.getItemDamage() + 1);
+		container.stackSize = 1;
+		return container;
+	}
+
+	@Override
+	public boolean hasContainerItem(ItemStack stack)
+	{
+		return true;
+	}
+
+	@Override
+	public boolean isRepairable()
+	{
+		return false;
+	}
+
+	@Override
 	public EnumSize getSize(ItemStack is)
 	{
 		return EnumSize.LARGE;

--- a/src/Common/com/bioxx/tfc/Items/Tools/ItemKnife.java
+++ b/src/Common/com/bioxx/tfc/Items/Tools/ItemKnife.java
@@ -29,6 +29,39 @@ public class ItemKnife extends ItemWeapon implements IKnife
 	}
 
 	@Override
+	public boolean doesContainerItemLeaveCraftingGrid(ItemStack ItemStack)
+	{
+		return false;
+	}
+
+	@Override
+	public boolean getShareTag()
+	{
+		return true;
+	}
+
+	@Override
+	public ItemStack getContainerItem(ItemStack itemStack)
+	{
+		ItemStack container = itemStack.copy();
+		container.setItemDamage(container.getItemDamage() + 1);
+		container.stackSize = 1;
+		return container;
+	}
+
+	@Override
+	public boolean hasContainerItem(ItemStack stack)
+	{
+		return true;
+	}
+
+	@Override
+	public boolean isRepairable()
+	{
+		return false;
+	}
+
+	@Override
 	public EnumSize getSize(ItemStack is)
 	{
 		return EnumSize.SMALL;

--- a/src/Common/com/bioxx/tfc/Items/Tools/ItemSpindle.java
+++ b/src/Common/com/bioxx/tfc/Items/Tools/ItemSpindle.java
@@ -25,9 +25,43 @@ public class ItemSpindle extends ItemTerra
 	{
 		return HashMultimap.create();
 	}
-	
+
 	@Override
-	public EnumItemReach getReach(ItemStack is){
+	public boolean doesContainerItemLeaveCraftingGrid(ItemStack ItemStack)
+	{
+		return false;
+	}
+
+	@Override
+	public boolean getShareTag()
+	{
+		return true;
+	}
+
+	@Override
+	public ItemStack getContainerItem(ItemStack itemStack)
+	{
+		ItemStack container = itemStack.copy();
+		container.setItemDamage(container.getItemDamage() + 1);
+		container.stackSize = 1;
+		return container;
+	}
+
+	@Override
+	public boolean hasContainerItem(ItemStack stack)
+	{
+		return true;
+	}
+
+	@Override
+	public boolean isRepairable()
+	{
+		return false;
+	}
+
+	@Override
+	public EnumItemReach getReach(ItemStack is)
+	{
 		return EnumItemReach.SHORT;
 	}
 

--- a/src/Common/com/bioxx/tfc/Items/Tools/ItemTerraTool.java
+++ b/src/Common/com/bioxx/tfc/Items/Tools/ItemTerraTool.java
@@ -79,6 +79,39 @@ public class ItemTerraTool extends ItemTool implements ISize
 	}
 
 	@Override
+	public boolean doesContainerItemLeaveCraftingGrid(ItemStack ItemStack)
+	{
+		return false;
+	}
+
+	@Override
+	public boolean getShareTag()
+	{
+		return true;
+	}
+
+	@Override
+	public ItemStack getContainerItem(ItemStack itemStack)
+	{
+		ItemStack container = itemStack.copy();
+		container.setItemDamage(container.getItemDamage() + 1);
+		container.stackSize = 1;
+		return container;
+	}
+
+	@Override
+	public boolean hasContainerItem(ItemStack stack)
+	{
+		return true;
+	}
+
+	@Override
+	public boolean isRepairable()
+	{
+		return false;
+	}
+
+	@Override
 	public EnumItemReach getReach(ItemStack is)
 	{
 		return EnumItemReach.SHORT;


### PR DESCRIPTION
damage on tools used in crafting. This change allows the tools to be
used in autocrafters that do not trigger a crafting event without being
destroyed. It overrides methods in MC’s Item class.