### PR TITLE
Fixed Eternal Armor

### DIFF
--- a/src/Common/com/bioxx/tfc/Containers/ContainerLiquidVessel.java
+++ b/src/Common/com/bioxx/tfc/Containers/ContainerLiquidVessel.java
@@ -107,7 +107,7 @@ public class ContainerLiquidVessel extends ContainerTFC
 			{
 				if (input != null && input.getItem() == TFCItems.ceramicMold && input.getItemDamage() == 1 && input.stackSize == 1 && metalAmount > 0)
 				{
-					int amt = 99;
+					int amt = 100; //+++ REWRITTEN [Precision Smelter]
 					ItemStack is = new ItemStack(m.meltedItem, 1, amt);
 					TFC_ItemHeat.setTemp(is, (short) (HeatRegistry.getInstance().getMeltingPoint(is) * 1.5f));
 					containerInv.setInventorySlotContents(0, is);
@@ -125,7 +125,7 @@ public class ContainerLiquidVessel extends ContainerTFC
 
 					stack.setTagCompound(nbt);
 				}
-				else if (input != null && input.getItem() == m.meltedItem && input.getItemDamage() > 0)
+				else if (input != null && input.getItem() == m.meltedItem && input.getItemDamage() > 1) // +++ REWRITTEN [Precision Smelter]
 				{
 					input.setItemDamage(input.getItemDamage() - 1);
 					TFC_ItemHeat.setTemp(input, (short) (HeatRegistry.getInstance().getMeltingPoint(input) * 1.5f));

--- a/src/Common/com/bioxx/tfc/Containers/ContainerMold.java
+++ b/src/Common/com/bioxx/tfc/Containers/ContainerMold.java
@@ -105,7 +105,7 @@ public class ContainerMold extends ContainerTFC
 				if (sourceItem instanceof ItemMeltedMetal && inputItem == TFCItems.ceramicMold && inputDamage == 1 && TFC_ItemHeat.getIsLiquid(sourceStack))
 				{
 					ItemStack is = sourceStack.copy();
-					is.setItemDamage(100);
+					is.setItemDamage(101); //+++ REWRITTEN [Precision Smelter]
 					containerInv.setInventorySlotContents(1, is);
 					pi.moldTransferTimer = 100;
 				}
@@ -135,17 +135,20 @@ public class ContainerMold extends ContainerTFC
 			{
 				Item sourceItem = sourceStack.getItem();
 				Item inputItem = inputStack.getItem();
-				int newSourceDamage = sourceStack.getItemDamage() + 1;
-				int inputDamage = inputStack.getItemDamage();
 				ItemStack recipeOutput = CraftingManagerTFC.getInstance().findMatchingRecipe(this.containerInv, world);
 
 				if (sourceItem instanceof ItemMeltedMetal && inputItem instanceof ItemMeltedMetal)
+				// Ingot_Mold to Ingot_Mold transfer:
+				// +++ BEGIN REWRITTEN CODE [Precision Smelter] +++ 
 				{
-					if (sourceItem == inputItem && inputDamage != 0)
+					int sourceUnits = ((ItemMeltedMetal) sourceItem).getMetalUnits(sourceStack);
+					int inputUnits = ((ItemMeltedMetal) inputItem).getMetalUnits(inputStack);
+					if (sourceItem == inputItem && sourceUnits > 0 && inputUnits < 100)
 					{
-						sourceStack.setItemDamage(newSourceDamage);
-						inputStack.setItemDamage(inputDamage - 1);
-						if (newSourceDamage >= sourceStack.getMaxDamage() - 1) // Subtract one so we never have an unshaped metal with 0/100 units
+						((ItemMeltedMetal) sourceItem).setMetalUnits(sourceStack, sourceUnits - 1);
+						((ItemMeltedMetal) inputItem).setMetalUnits(inputStack, inputUnits + 1);
+						if (sourceUnits <= 1 )
+				// +++ END REWRITTEN CODE +++ 
 						{
 							containerInv.setInventorySlotContents(0, new ItemStack(TFCItems.ceramicMold, 1, 1));
 						}

--- a/src/Common/com/bioxx/tfc/Handlers/EntityDamageHandler.java
+++ b/src/Common/com/bioxx/tfc/Handlers/EntityDamageHandler.java
@@ -140,7 +140,7 @@ public class EntityDamageHandler
 
 				//5. Damage the armor that was hit
 				armor[location].damageItem((int) processArmorDamage(armor[location], damage), entity);
-				if (armor[location].stackSize <= 0)  armor[location] = null; //+++ NEW CODE [Precision Smelter] +++ 
+				if (armor[location].stackSize <= 0)  armor[location] = null; //+++ NEW CODE [Precision Smelter] +++
 			}
 			else if (armor[location] == null || armor[location] != null && !(armor[location].getItem() instanceof ItemTFCArmor))
 			{

--- a/src/Common/com/bioxx/tfc/Handlers/EntityDamageHandler.java
+++ b/src/Common/com/bioxx/tfc/Handlers/EntityDamageHandler.java
@@ -141,7 +141,7 @@ public class EntityDamageHandler
 				//5. Damage the armor that was hit
 				armor[location].damageItem((int) processArmorDamage(armor[location], damage), entity);
 				if (armor[location].stackSize <= 0)  armor[location] = null; //+++ NEW CODE [Precision Smelter] +++ 
-				}
+			}
 			else if (armor[location] == null || armor[location] != null && !(armor[location].getItem() instanceof ItemTFCArmor))
 			{
 				if(entity instanceof IInnateArmor)

--- a/src/Common/com/bioxx/tfc/Handlers/EntityDamageHandler.java
+++ b/src/Common/com/bioxx/tfc/Handlers/EntityDamageHandler.java
@@ -140,7 +140,8 @@ public class EntityDamageHandler
 
 				//5. Damage the armor that was hit
 				armor[location].damageItem((int) processArmorDamage(armor[location], damage), entity);
-			}
+				if (armor[location].stackSize <= 0)  armor[location] = null; //+++ NEW CODE [Precision Smelter] +++ 
+				}
 			else if (armor[location] == null || armor[location] != null && !(armor[location].getItem() instanceof ItemTFCArmor))
 			{
 				if(entity instanceof IInnateArmor)

--- a/src/Common/com/bioxx/tfc/Items/ItemMeltedMetal.java
+++ b/src/Common/com/bioxx/tfc/Items/ItemMeltedMetal.java
@@ -47,16 +47,54 @@ public class ItemMeltedMetal extends ItemTerra
 
 		return super.getItemStackLimit(is);
 	}
-
+	
 	@Override
 	public void addItemInformation(ItemStack is, EntityPlayer player, List<String> arraylist)
 	{		
-		if (is.getItemDamage() > 1)
+// +++ BEGIN REWRITTEN CODE [Precision Smelter] +++ 
+		int u = ((ItemMeltedMetal) is.getItem()).getMetalUnits(is);
+		if (u < 100)
 		{
-			arraylist.add(TFC_Core.translate("gui.units") + ": " + (100 - is.getItemDamage()) + " / 100");
+			arraylist.add(TFC_Core.translate("gui.units") + ": " + u + " / 100");
 		}
+// +++ END REWRITTEN CODE +++ 
 	}
 
+// +++ BEGIN NEW CODE [Precision Smelter] +++ 
+/* These new "getMetalUnits" & "setMetalUnits" methods implement    
+   the most logical & unambiguous way to define the amount of Metal Units in a mold based on its ItemDamage:   
+  	Damage 	Units	State
+	------	-----	-----
+	0		100 	solid
+	1		100		liquid
+	2		99		any
+	...
+	x		101-x	any
+	... 
+	100		1		any
+	101		0		any
+
+    *In the old code Damage=1 meant 2 things: "100 units liquid" & "99 units any", which caused several glitches
+*/	
+	public int getMetalUnits(ItemStack is)
+    {
+    	int d = is.getItemDamage();
+    	if (d <= 1)  return 100;
+    	else  return 101 - d;
+    }
+
+	public void setMetalUnits(ItemStack is, int u)
+    {
+    	if (u < 100)  is.setItemDamage(101 - Math.max(0,u));
+    	else
+    	{
+    		if(TFC_ItemHeat.hasTemp(is) && TFC_ItemHeat.getTemp(is) >= TFC_ItemHeat.isCookable(is))
+    			is.setItemDamage(1);
+    		else  is.setItemDamage(0);
+        }
+    }
+// +++ END NEW CODE +++ 
+    
 	@Override
 	public void onUpdate(ItemStack is, World world, Entity entity, int i, boolean isSelected) 
 	{

--- a/src/Common/com/bioxx/tfc/Items/ItemMeltedMetal.java
+++ b/src/Common/com/bioxx/tfc/Items/ItemMeltedMetal.java
@@ -47,7 +47,7 @@ public class ItemMeltedMetal extends ItemTerra
 
 		return super.getItemStackLimit(is);
 	}
-	
+
 	@Override
 	public void addItemInformation(ItemStack is, EntityPlayer player, List<String> arraylist)
 	{		
@@ -65,14 +65,14 @@ public class ItemMeltedMetal extends ItemTerra
    the most logical & unambiguous way to define the amount of Metal Units in a mold based on its ItemDamage:   
   	Damage 	Units	State
 	------	-----	-----
-	0		100 	solid
-	1		100		liquid
-	2		99		any
+	0	100 	solid
+	1	100	liquid
+	2	99	any
 	...
-	x		101-x	any
-	... 
-	100		1		any
-	101		0		any
+	x	101-x	any
+	...
+	100	1	any
+	101	0	any
 
     *In the old code Damage=1 meant 2 things: "100 units liquid" & "99 units any", which caused several glitches
 */	


### PR DESCRIPTION
Wow, I am on a roll today. Adding a single line to ‘EntityDamageHandler.java’ fixes a years old TFC “feature”: the eternal armor, which can never be destroyed by regular mob damage (damage other than explosions, fire & cacti).

Here is the magic line:
143:	if (armor[location].stackSize <= 0)  armor[location] = null; 
 